### PR TITLE
add "last-used" as a budget choice

### DIFF
--- a/Api/Account/AccountQueryService.cs
+++ b/Api/Account/AccountQueryService.cs
@@ -4,7 +4,7 @@
     {
         public async Task<IReadOnlyCollection<Account>> GetBudgetAccounts(Budget.Budget selectedBudget)
         {
-            var response = await ynabApi.GetBudgetAccountsAsync(selectedBudget.Id);
+            var response = await ynabApi.GetBudgetAccountsAsync(selectedBudget.BudgetId);
 
             return response.Data?.Accounts ?? new []{ new Account() };
         }

--- a/Api/Budget/BudgetQueryService.cs
+++ b/Api/Budget/BudgetQueryService.cs
@@ -9,7 +9,7 @@ namespace YnabApi.Budget
             Budget selectedBudget
         )
         {
-            var response = await ynabApi.GetBudgetCategoriesAsync(selectedBudget.Id);
+            var response = await ynabApi.GetBudgetCategoriesAsync(selectedBudget.BudgetId);
 
             return response.Data?.Groups ?? new []{ new CategoryGroup() };
         }

--- a/Api/Category/CategoryQueryService.cs
+++ b/Api/Category/CategoryQueryService.cs
@@ -4,7 +4,7 @@
     {
         public async Task<IReadOnlyCollection<CategoryGroup>> GetBudgetCategoriesAsync(Budget.Budget budget)
         {
-            var response = await ynabApi.GetBudgetCategoriesAsync(budget.Id);
+            var response = await ynabApi.GetBudgetCategoriesAsync(budget.BudgetId);
             
             return response.Data?.Groups ?? new []{ new CategoryGroup() };
         }

--- a/Api/IYnabApi.cs
+++ b/Api/IYnabApi.cs
@@ -12,9 +12,9 @@ namespace YnabApi
         [Get("/budgets/{id}/months/{month}")]
         internal Task<QueryResponse<BudgetMonthResponse>> GetBudgetMonthAsync(string id, string month);
         [Get("/budgets/{id}/categories")]
-        internal Task<QueryResponse<CategoryResponse>> GetBudgetCategoriesAsync(Guid id);
+        internal Task<QueryResponse<CategoryResponse>> GetBudgetCategoriesAsync(string id);
 
         [Get("/budgets/{id}/accounts")]
-        internal Task<QueryResponse<AccountResponse>> GetBudgetAccountsAsync(Guid id);
+        internal Task<QueryResponse<AccountResponse>> GetBudgetAccountsAsync(string id);
     }
 }

--- a/Console/YnabConsole.cs
+++ b/Console/YnabConsole.cs
@@ -147,7 +147,6 @@ class YnabConsole(IBudgetQueryService budgetQueryService) : IYnabConsole
 
 	private Budget PromptBudgetSelection(IReadOnlyCollection<Budget> budgets)
 	{
-		// todo: finish implementing last-used as a budget selection
 		var lastUsedBudget = new Budget
 		{
 			Name = "last-used",
@@ -158,7 +157,7 @@ class YnabConsole(IBudgetQueryService budgetQueryService) : IYnabConsole
 				.Title("[italic grey]Select a[/] [underline italic aqua]budget:[/]")
 				.PageSize(10)
 				.MoreChoicesText("[grey](Move up and down to reveal more budgets)[/]")
-				.AddChoices(budgets)
+				.AddChoices([lastUsedBudget, ..budgets])
 				.UseConverter(budget => budget.ToString() + $" [grey]{budget.BudgetId}[/]")
 			);
 		


### PR DESCRIPTION
Fixes #9 

Allows for "Last Used Budget" as a budget choice. Does not require internal state management, however, a future version may implement this with state. 

This is because "last-used" is a feature provided by the YNAB API but it requires the user to have interacted with a budget before selecting this choice. Last used would be the default choice when running ynac but it would likely throw an error when selected if the user has never opened a budget before via their current API token.