### PR TITLE
Improve budget filtering, allow "last-used" as an argument

### DIFF
--- a/Api/Budget/Budget.cs
+++ b/Api/Budget/Budget.cs
@@ -26,8 +26,10 @@ namespace YnabApi.Budget
             return Name;
         }
         
-        public static Budget LastUsedBudget => new() { Name = LastUsedBudgetName, Id = Guid.Empty };
+        public static readonly Budget LastUsedBudget = new() { Name = LastUsedBudgetName, Id = Guid.Empty };
+        public static readonly Budget NoBudget = new() { Name = NoBudgetsFoundText, Id = Guid.Empty };
         private static string LastUsedBudgetName => "last-used";
+        private static string NoBudgetsFoundText => "ynac:error:no-budgets-found";
         private static string LastUsedBudgetDescription => "Last Used Budget";
     }
 }

--- a/Api/Budget/BudgetQueryService.cs
+++ b/Api/Budget/BudgetQueryService.cs
@@ -1,16 +1,44 @@
-﻿using YnabApi.Account;
-using YnabApi.Category;
+﻿using YnabApi.Category;
 
 namespace YnabApi.Budget
 {
+    public record BudgetCategorySearchOptions
+    {
+        public Budget? SelectedBudget { get; set; }
+        public string? CategoryFilter { get; set; }
+        public bool ShowHiddenCategories { get; set; }
+        public bool ShowDeletedCategories { get; set; }
+    }
+
     public class BudgetQueryService(IYnabApi ynabApi) : IBudgetQueryService
     {
-        public async Task<IReadOnlyCollection<CategoryGroup>> GetBudgetCategories(
-            Budget selectedBudget,
-            string? categoryFilter = null
-        )
+        private BudgetCategorySearchOptions _options = new();
+        private void Configure(Action<BudgetCategorySearchOptions> budgetAction)
         {
-            var response = await ynabApi.GetBudgetCategoriesAsync(selectedBudget.BudgetId);
+            budgetAction(_options);
+        }
+        
+        public async Task<IReadOnlyCollection<CategoryGroup>> GetBudgetCategories(Action<BudgetCategorySearchOptions> configureOptions)
+        {
+            ArgumentNullException.ThrowIfNull(configureOptions, nameof(configureOptions));
+            Configure(configureOptions);
+            
+            return await GetBudgetCategories();
+        }
+
+        public async Task<IReadOnlyCollection<CategoryGroup>> GetBudgetCategories(BudgetCategorySearchOptions budgetCategorySearchSettings)
+        {
+            ArgumentNullException.ThrowIfNull(budgetCategorySearchSettings, nameof(budgetCategorySearchSettings));
+            _options = budgetCategorySearchSettings;
+
+            return await GetBudgetCategories();
+        }
+
+        private async Task<IReadOnlyCollection<CategoryGroup>> GetBudgetCategories()
+        {
+            ArgumentNullException.ThrowIfNull(_options.SelectedBudget, nameof(_options.SelectedBudget));
+            
+            var response = await ynabApi.GetBudgetCategoriesAsync(_options.SelectedBudget.BudgetId);
 
             // first group is the "Internal Master Category" used by YNAB, so we skip it
             var filteredGroups = response.Data?.Groups?
@@ -18,21 +46,42 @@ namespace YnabApi.Budget
                 .Where(group => !group.Deleted)
                 .Skip(1);
 
-            if (!string.IsNullOrWhiteSpace(categoryFilter))
+            if (!string.IsNullOrWhiteSpace(_options.CategoryFilter))
             {
                 filteredGroups = filteredGroups?
-                    .Where(group => group.Name.Contains(categoryFilter, StringComparison.OrdinalIgnoreCase))
+                    .Where(group => group.Name.Contains(_options.CategoryFilter, StringComparison.OrdinalIgnoreCase))
                     .ToList();
             }
             
             return filteredGroups?.ToList() ?? [new CategoryGroup()];
         }
-
-        public async Task<IReadOnlyCollection<Budget>> GetBudgets()
+        
+        public async Task<IReadOnlyCollection<Budget>> GetBudgets(string? filter)
         {
             var response = await ynabApi.GetBudgetsAsync();
 
-            return response.Data?.Budgets ?? [ new Budget() ];
+            var budgets = response.Data?.Budgets;
+            
+            if (budgets == null || !budgets.Any())
+            {
+                return [ Budget.NoBudget ];
+            }
+
+            IReadOnlyCollection<Budget> budgetList = [ Budget.LastUsedBudget, ..budgets ];
+
+            if (!string.IsNullOrWhiteSpace(filter))
+            {
+                budgetList = budgetList
+                    .Where(budget => budget.Name.Contains(filter, StringComparison.OrdinalIgnoreCase))
+                    .ToList();
+            }
+            
+            if (budgetList.Count == 0)
+            {
+                budgetList = [ Budget.NoBudget ];
+            }
+
+            return budgetList;
         }
         
         public async Task<BudgetMonth> GetBudgetMonth(Budget budget, DateOnly date)

--- a/Api/Budget/IBudgetQueryService.cs
+++ b/Api/Budget/IBudgetQueryService.cs
@@ -4,9 +4,10 @@ namespace YnabApi.Budget
 {
     public interface IBudgetQueryService
     {
-        Task<IReadOnlyCollection<Budget>> GetBudgets();
+        Task<IReadOnlyCollection<Budget>> GetBudgets(string? filter);
         Task<BudgetMonth> GetBudgetMonth(Budget budget, DateOnly date);
         Task<BudgetMonth> GetCurrentMonthBudget(Budget selectedBudget);
-        Task<IReadOnlyCollection<CategoryGroup>> GetBudgetCategories(Budget selectedBudget, string? categoryFilter = null);
+        Task<IReadOnlyCollection<CategoryGroup>> GetBudgetCategories(Action<BudgetCategorySearchOptions> configureOptions);
+        Task<IReadOnlyCollection<CategoryGroup>> GetBudgetCategories(BudgetCategorySearchOptions budgetCategorySearchSettings);
     }
 }

--- a/Console/YnabConsole.cs
+++ b/Console/YnabConsole.cs
@@ -48,19 +48,14 @@ class YnabConsole(IBudgetQueryService budgetQueryService) : IYnabConsole
 		}
 			
 		var selectedBudgetFull = await budgetQueryService.GetCurrentMonthBudget(selectedBudget);
-		var budgetCategoryGroups = await budgetQueryService.GetBudgetCategories(selectedBudget, categoryFilter);
+		var categoryGroups = await budgetQueryService.GetBudgetCategories(options =>
+		{
+			options.SelectedBudget = selectedBudget;
+			options.CategoryFilter = categoryFilter;
+		});
 		
 		var table = CreateTable(selectedBudget.Name, selectedBudgetFull);
 
-		// skip last category group, this is the "hidden" group that includes categories hidden by the user
-		var categoryGroups = budgetCategoryGroups
-			.SkipLast(1);
-		
-		if (!string.IsNullOrWhiteSpace(categoryFilter))
-		{
-			categoryGroups = categoryGroups.Where(c => c.Name.Contains(categoryFilter, StringComparison.OrdinalIgnoreCase));
-		}
-        
 		foreach (var categoryGroup in categoryGroups)
 		{
 			var subTable = new Table()


### PR DESCRIPTION
Allows for filtering to all of the budgets found by the filter passed as the first argument on the command line.
Previously the first found budget was automatically selected.

Additonally, `last-used` can be passed as the first argument on the command line to default to the last used budget, however it is a less than ideal experience due to the issues described in #9.

Draft until the following are included in this PR:
- need to hide `last-used` if `--open` flag is passed, feature was inadvertently removed
- Display an error if `last-used` and `--open` are included on the command line together, this may be easier if last-used is changed to its own argument e.g. `--last-used`

Fixes #24 
Fixes #9 