### PR TITLE
implement filter by budget id

### DIFF
--- a/Console/IBudgetPrompter.cs
+++ b/Console/IBudgetPrompter.cs
@@ -12,6 +12,11 @@ public class BudgetPrompter : IBudgetPrompter
 {
     public Budget PromptBudgetSelection(IReadOnlyCollection<Budget> budgets)
     {
+        if (budgets.Count == 0)
+        {
+            return Budget.NoBudget;
+        }
+        
         // if there is only one budget, select it automatically
         if (budgets.Count == 1)
         {

--- a/Console/IBudgetSelector.cs
+++ b/Console/IBudgetSelector.cs
@@ -42,6 +42,13 @@ public class BudgetSelector : IBudgetSelector
 	    {
 		    return Budget.NoBudget;
 	    }
+	   
+	    // if a guid was passed in, use it to select the budget directly
+	    if (Guid.TryParse(budgetFilter, out var budgetId))
+	    {
+		    _selectedBudget = _budgets.FirstOrDefault(budget => budget.Id == budgetId);
+		    return _selectedBudget ?? Budget.NoBudget;
+	    }
 	    
 	    IReadOnlyCollection<Budget> filteredBudgets = [ Budget.LastUsedBudget, .._budgets];
 

--- a/Console/YnabConsole.cs
+++ b/Console/YnabConsole.cs
@@ -155,8 +155,6 @@ class YnabConsole(
 		return table;
 	}
 
-	
-
 	private static void WriteHeaderRule(string title)
 	{
 		var rule = new Rule(title);


### PR DESCRIPTION
Fixes #27 

Allows for passing a guid as a budget filter. Will select the budget with the GUID passed in as the first argument on the command line. Only searches by GUID if a valid GUID is detected. Otherwise, it will fallback to text search.

If no budget is found, error will indicate as much.