### PR TITLE
Add tests around budget prompter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,5 +18,7 @@ jobs:
         dotnet-version: 8.0.x
     - name: build
       run: dotnet build
+    - name: test
+      run: dotnet test
     - name: publish
       run: dotnet publish -r win-x64

--- a/ynac.cli/BudgetSelection/BudgetPrompter.cs
+++ b/ynac.cli/BudgetSelection/BudgetPrompter.cs
@@ -23,13 +23,49 @@ public class ConsolePrompt : IConsolePrompt
     }
 }
 
-public class BudgetPrompter : IBudgetPrompter
+public interface IPrompter
+{
+    T PromptSelection<T>(IReadOnlyCollection<T> items, string title, Func<T, string> converter) where T : notnull;
+}
+
+public abstract class PrompterBase : IPrompter
 {
     private readonly IConsolePrompt _console;
-    public BudgetPrompter(IConsolePrompt console)
+
+    protected PrompterBase(IConsolePrompt console)
     {
         _console = console;
     }
+
+    public T PromptSelection<T>(IReadOnlyCollection<T> items, string title, Func<T, string> converter) where T : notnull
+    {
+        if (items.Count == 0)
+        {
+            throw new ArgumentException("No items to select from.", nameof(items));
+        }
+
+        if (items.Count == 1)
+        {
+            return items.First();
+        }
+
+        return _console.Prompt(
+            new SelectionPrompt<T>()
+                .Title(title)
+                .PageSize(10)
+                .MoreChoicesText("[grey](Move up and down to reveal more choices)[/]")
+                .AddChoices(items)
+                .UseConverter(converter)
+        );
+    }
+}
+
+public class BudgetPrompter : PrompterBase, IBudgetPrompter
+{
+    public BudgetPrompter(IConsolePrompt console) 
+        : base(console)
+    { }
+        
     public Budget PromptBudgetSelection(IReadOnlyCollection<Budget> budgets)
     {
         if (budgets.Count == 0)
@@ -43,15 +79,6 @@ public class BudgetPrompter : IBudgetPrompter
             return budgets.First();
         }
             		
-        var selectedBudget = _console.Prompt(
-            new SelectionPrompt<Budget>()
-                .Title("[italic grey]Select a[/] [italic aqua]budget:[/]")
-                .PageSize(10)
-                .MoreChoicesText("[grey](Move up and down to reveal more budgets)[/]")
-                .AddChoices(budgets)
-                .UseConverter(budget => $"{budget} [grey]{budget.BudgetId}[/]")
-        );
-	     
-        return selectedBudget;
+        return PromptSelection(budgets, "[italic grey]Select a[/] [italic aqua]budget:[/]", budget => $"{budget} [grey]{budget.BudgetId}[/]");
     }
 }

--- a/ynac.cli/BudgetSelection/BudgetPrompter.cs
+++ b/ynac.cli/BudgetSelection/BudgetPrompter.cs
@@ -3,8 +3,33 @@ using YnabApi.Budget;
 
 namespace ynac.BudgetSelection;
 
+public interface IConsolePrompt
+{
+    T Prompt<T>(SelectionPrompt<T> prompt) where T : notnull;
+}
+
+public class ConsolePrompt : IConsolePrompt
+{
+    private readonly IAnsiConsole _console;
+
+    public ConsolePrompt(IAnsiConsole console)
+    {
+        _console = console;
+    }
+
+    public T Prompt<T>(SelectionPrompt<T> prompt) where T : notnull
+    {
+        return _console.Prompt(prompt);
+    }
+}
+
 public class BudgetPrompter : IBudgetPrompter
 {
+    private readonly IConsolePrompt _console;
+    public BudgetPrompter(IConsolePrompt console)
+    {
+        _console = console;
+    }
     public Budget PromptBudgetSelection(IReadOnlyCollection<Budget> budgets)
     {
         if (budgets.Count == 0)
@@ -18,7 +43,7 @@ public class BudgetPrompter : IBudgetPrompter
             return budgets.First();
         }
             		
-        var selectedBudget = AnsiConsole.Prompt(
+        var selectedBudget = _console.Prompt(
             new SelectionPrompt<Budget>()
                 .Title("[italic grey]Select a[/] [italic aqua]budget:[/]")
                 .PageSize(10)

--- a/ynac.cli/BudgetSelection/IBudgetPrompter.cs
+++ b/ynac.cli/BudgetSelection/IBudgetPrompter.cs
@@ -2,7 +2,7 @@ using YnabApi.Budget;
 
 namespace ynac.BudgetSelection;
 
-public interface IBudgetPrompter
+public interface IBudgetPrompter : IPrompter
 {
     public Budget PromptBudgetSelection(IReadOnlyCollection<Budget> budgets);
 }

--- a/ynac.cli/Commands/BudgetCommand.cs
+++ b/ynac.cli/Commands/BudgetCommand.cs
@@ -10,7 +10,7 @@ public sealed class BudgetCommand : AsyncCommand<BudgetCommand.Settings>
 {
     public sealed class Settings : CommandSettings
     {
-        [Description("The budget name to filter to. If more than one budget matches the filter string, a selection promp will be presented.")]
+        [Description("The budget name to filter to. If more than one budget matches the filter string, a selection prompt will be presented.")]
         [CommandArgument(0, "[budgetFilter]")]
         public string? BudgetFilter { get; init; }
 

--- a/ynac.sln
+++ b/ynac.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YnabApi", "ynab.api\YnabApi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ynac", "ynac.cli\ynac.csproj", "{628CFF60-8D0F-44AB-A660-30BB1E1D4CDC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ynac.tests", "ynac.tests\ynac.tests.csproj", "{09D04D98-BAD4-4EE9-AB69-5836CE8FF237}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,5 +26,9 @@ Global
 		{628CFF60-8D0F-44AB-A660-30BB1E1D4CDC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{628CFF60-8D0F-44AB-A660-30BB1E1D4CDC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{628CFF60-8D0F-44AB-A660-30BB1E1D4CDC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{09D04D98-BAD4-4EE9-AB69-5836CE8FF237}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{09D04D98-BAD4-4EE9-AB69-5836CE8FF237}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{09D04D98-BAD4-4EE9-AB69-5836CE8FF237}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{09D04D98-BAD4-4EE9-AB69-5836CE8FF237}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/ynac.tests/BudgetSelection/BudgetPrompterTests.cs
+++ b/ynac.tests/BudgetSelection/BudgetPrompterTests.cs
@@ -1,0 +1,45 @@
+using System.Diagnostics.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using YnabApi.Budget;
+using ynac.BudgetSelection;
+
+namespace ynac.Tests.BudgetSelection;
+
+[TestClass]
+[SuppressMessage("ReSharper", "CollectionNeverUpdated.Local")]
+public class BudgetPrompterTests
+{
+    private BudgetPrompter? _sut;
+
+    [TestMethod]
+    public void PromptBudgetSelection_ReturnsNoBudgetIfEmpty()
+    {
+        // Arrange
+        _sut = new BudgetPrompter();
+        var budgets = new List<Budget>();
+        
+        // Act
+        var result = _sut.PromptBudgetSelection(budgets);
+        
+        // Assert
+        Assert.AreEqual(Budget.NoBudget, result);
+    }
+    
+    [TestMethod]
+    public void PromptBudgetSelection_ReturnsFirstBudgetIfOnlyOne()
+    {
+        // Arrange
+        _sut = new BudgetPrompter();
+        var budget = new Budget { Id = Guid.NewGuid(), Name = "Budget 1" };
+        var budgets = new List<Budget> { budget };
+        
+        // Act
+        var result = _sut.PromptBudgetSelection(budgets);
+        
+        // Assert
+        Assert.AreEqual(budget.BudgetId, result.BudgetId);
+        Assert.AreEqual(budget.Id, result.Id);
+    }
+    
+    
+}

--- a/ynac.tests/BudgetSelection/BudgetPrompterTests.cs
+++ b/ynac.tests/BudgetSelection/BudgetPrompterTests.cs
@@ -58,9 +58,7 @@ public class BudgetPrompterTests
             new Budget { Id = Guid.NewGuid(), Name = "Budget 2" },
             new Budget { Id = Guid.NewGuid(), Name = "Budget 3" },
         };
-        var prompt = Substitute.For<IPrompt<Budget>>();
         _console.Prompt(Arg.Any<SelectionPrompt<Budget>>()).Returns(budgets[1]);
-        //prompt.Show(_console).Returns(budgets[1]);
                 
         // Act
         var result = _sut.PromptBudgetSelection(budgets);

--- a/ynac.tests/TokenHandlerTests.cs
+++ b/ynac.tests/TokenHandlerTests.cs
@@ -1,0 +1,5 @@
+﻿namespace ynac.Tests;
+
+public class TokenHandlerTests
+{
+}

--- a/ynac.tests/ynac.tests.csproj
+++ b/ynac.tests/ynac.tests.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <RootNamespace>ynac.Tests</RootNamespace>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+      <PackageReference Include="MSTest.TestAdapter" Version="3.5.1" />
+      <PackageReference Include="MSTest.TestFramework" Version="3.5.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\ynac.cli\ynac.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/ynac.tests/ynac.tests.csproj
+++ b/ynac.tests/ynac.tests.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <PackageReference Include="FluentAssertions" Version="6.12.0" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
       <PackageReference Include="MSTest.TestAdapter" Version="3.5.1" />
       <PackageReference Include="MSTest.TestFramework" Version="3.5.1" />

--- a/ynac.tests/ynac.tests.csproj
+++ b/ynac.tests/ynac.tests.csproj
@@ -11,6 +11,7 @@
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
       <PackageReference Include="MSTest.TestAdapter" Version="3.5.1" />
       <PackageReference Include="MSTest.TestFramework" Version="3.5.1" />
+      <PackageReference Include="NSubstitute" Version="5.1.0" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Adds a few unit tests just because I wanted to get back into testing. Tests also help to indicate issues with code that is getting a bit too reliant on anti-testable coding practices. Better to start ironing those issues out now.