### PR TITLE
Remove Refit and Polly with manually created classes and Microsoft.Extension.Http.Resilience package

### DIFF
--- a/ynab.api/IYnabApi.cs
+++ b/ynab.api/IYnabApi.cs
@@ -1,4 +1,5 @@
-﻿using Refit;
+﻿using System.Net.Http.Json;
+using Refit;
 using YnabApi.Account;
 using YnabApi.Budget;
 using YnabApi.Category;
@@ -16,5 +17,36 @@ namespace YnabApi
 
         [Get("/budgets/{id}/accounts")]
         internal Task<QueryResponse<AccountResponse>> GetBudgetAccountsAsync(string id);
+    }
+
+    public class YnabApi : IYnabApi
+    {
+        private readonly HttpClient _httpClient;
+        public YnabApi(IHttpClientFactory httpClientFactory)
+        {
+            _httpClient = httpClientFactory.CreateClient(nameof(YnabApi));
+        }
+        
+        public async Task<QueryResponse<BudgetResponse>> GetBudgetsAsync()
+        {
+            var path = "budgets";
+            var budgets = await _httpClient.GetFromJsonAsync<QueryResponse<BudgetResponse>>(path);
+            return budgets;
+        }
+
+        public Task<QueryResponse<BudgetMonthResponse>> GetBudgetMonthAsync(string id, string month)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<QueryResponse<CategoryResponse>> GetBudgetCategoriesAsync(string id)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<QueryResponse<AccountResponse>> GetBudgetAccountsAsync(string id)
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/ynab.api/IYnabApi.cs
+++ b/ynab.api/IYnabApi.cs
@@ -1,7 +1,4 @@
-﻿using System.Diagnostics;
-using System.Net.Http.Json;
-using Refit;
-using YnabApi.Account;
+﻿using YnabApi.Account;
 using YnabApi.Budget;
 using YnabApi.Category;
 
@@ -9,88 +6,10 @@ namespace YnabApi
 {
     public interface IYnabApi
     {
-        [Get("/budgets")]
         internal Task<QueryResponse<BudgetResponse>> GetBudgetsAsync();
-        [Get("/budgets/{id}/months/{month}")]
         internal Task<QueryResponse<BudgetMonthResponse>> GetBudgetMonthAsync(string id, string month);
-        [Get("/budgets/{id}/categories")]
         internal Task<QueryResponse<CategoryResponse>> GetBudgetCategoriesAsync(string id);
 
-        [Get("/budgets/{id}/accounts")]
         internal Task<QueryResponse<AccountResponse>> GetBudgetAccountsAsync(string id);
-    }
-
-    public class YnabApi : IYnabApi
-    {
-        private readonly HttpClient _httpClient;
-        public YnabApi(IHttpClientFactory httpClientFactory)
-        {
-            _httpClient = httpClientFactory.CreateClient(nameof(YnabApi));
-        }
-        
-        public async Task<QueryResponse<BudgetResponse>> GetBudgetsAsync()
-        {
-            var path = "budgets";
-            var budgets = new QueryResponse<BudgetResponse>();
-            try
-            {
-                budgets = await _httpClient.GetFromJsonAsync<QueryResponse<BudgetResponse>>(path) ?? budgets;
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine(ex.ToString());
-            }
-
-            return budgets;
-        }
-
-        public async Task<QueryResponse<BudgetMonthResponse>> GetBudgetMonthAsync(string id, string month)
-        {
-            var path = $"budgets/{id}/months/{month}";
-            var budget = new QueryResponse<BudgetMonthResponse>();
-            try
-            {
-                budget = await _httpClient.GetFromJsonAsync<QueryResponse<BudgetMonthResponse>>(path) ?? budget;
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine(ex.ToString());
-            }
-            
-            return budget;
-        }
-
-        public async Task<QueryResponse<CategoryResponse>> GetBudgetCategoriesAsync(string id)
-        {
-
-            var path = $"budgets/{id}/categories";
-            var categories = new QueryResponse<CategoryResponse>();
-            try
-            {
-                categories = await _httpClient.GetFromJsonAsync<QueryResponse<CategoryResponse>>(path) ?? categories;
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine(ex.ToString());
-            }
-
-            return categories;
-        }
-
-        public async Task<QueryResponse<AccountResponse>> GetBudgetAccountsAsync(string id)
-        {
-
-            var path = $"budgets/{id}/accounts";
-            var accounts = new QueryResponse<AccountResponse>();
-            try
-            {
-                accounts = await _httpClient.GetFromJsonAsync<QueryResponse<AccountResponse>>(path) ?? accounts;
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine(ex.ToString());
-            }
-            return accounts;
-        }
     }
 }

--- a/ynab.api/IYnabApi.cs
+++ b/ynab.api/IYnabApi.cs
@@ -1,4 +1,5 @@
-﻿using System.Net.Http.Json;
+﻿using System.Diagnostics;
+using System.Net.Http.Json;
 using Refit;
 using YnabApi.Account;
 using YnabApi.Budget;
@@ -30,23 +31,66 @@ namespace YnabApi
         public async Task<QueryResponse<BudgetResponse>> GetBudgetsAsync()
         {
             var path = "budgets";
-            var budgets = await _httpClient.GetFromJsonAsync<QueryResponse<BudgetResponse>>(path);
+            var budgets = new QueryResponse<BudgetResponse>();
+            try
+            {
+                budgets = await _httpClient.GetFromJsonAsync<QueryResponse<BudgetResponse>>(path) ?? budgets;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex.ToString());
+            }
+
             return budgets;
         }
 
-        public Task<QueryResponse<BudgetMonthResponse>> GetBudgetMonthAsync(string id, string month)
+        public async Task<QueryResponse<BudgetMonthResponse>> GetBudgetMonthAsync(string id, string month)
         {
-            throw new NotImplementedException();
+            var path = $"budgets/{id}/months/{month}";
+            var budget = new QueryResponse<BudgetMonthResponse>();
+            try
+            {
+                budget = await _httpClient.GetFromJsonAsync<QueryResponse<BudgetMonthResponse>>(path) ?? budget;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex.ToString());
+            }
+            
+            return budget;
         }
 
-        public Task<QueryResponse<CategoryResponse>> GetBudgetCategoriesAsync(string id)
+        public async Task<QueryResponse<CategoryResponse>> GetBudgetCategoriesAsync(string id)
         {
-            throw new NotImplementedException();
+
+            var path = $"budgets/{id}/categories";
+            var categories = new QueryResponse<CategoryResponse>();
+            try
+            {
+                categories = await _httpClient.GetFromJsonAsync<QueryResponse<CategoryResponse>>(path) ?? categories;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex.ToString());
+            }
+
+            return categories;
         }
 
-        public Task<QueryResponse<AccountResponse>> GetBudgetAccountsAsync(string id)
+        public async Task<QueryResponse<AccountResponse>> GetBudgetAccountsAsync(string id)
         {
-            throw new NotImplementedException();
+
+            var path = $"budgets/{id}/accounts";
+            var accounts = new QueryResponse<AccountResponse>();
+            try
+            {
+                accounts = await _httpClient.GetFromJsonAsync<QueryResponse<AccountResponse>>(path) ?? accounts;
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex.ToString());
+            }
+            return accounts;
         }
     }
 }

--- a/ynab.api/ServiceCollectionExtensions.cs
+++ b/ynab.api/ServiceCollectionExtensions.cs
@@ -21,24 +21,36 @@ public static class YnabApiServiceCollectionExtensions
         if (string.IsNullOrWhiteSpace("token"))
             throw new ArgumentException("Valid YNAB API token is required", nameof(token));
 
-        services.AddRefitClient<IYnabApi>()
+     //   services.AddRefitClient<IYnabApi>()
+     //       .ConfigureHttpClient(
+     //           httpClient =>
+     //           {
+     //               var endpoint = YnabOptions.Endpoint;
+     //               var version = YnabOptions.Version;
+
+     //               httpClient.BaseAddress = new Uri($"{endpoint}/{version}");
+     //               httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
+     //           }
+     //       )
+     //       .AddPolicyHandler(
+     //           HttpPolicyExtensions
+     //               .HandleTransientHttpError()
+     //               .OrResult(msg => msg.StatusCode == System.Net.HttpStatusCode.NotFound)
+     //               .WaitAndRetryAsync(4, retry => TimeSpan.FromSeconds(Math.Pow(2, retry)))
+     //       );
+
+        services.AddHttpClient(nameof(YnabApi))
             .ConfigureHttpClient(
                 httpClient =>
                 {
                     var endpoint = YnabOptions.Endpoint;
                     var version = YnabOptions.Version;
 
-                    httpClient.BaseAddress = new Uri($"{endpoint}/{version}");
+                    httpClient.BaseAddress = new Uri($"{endpoint}/{version}/");
                     httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
-                }
-            )
-            .AddPolicyHandler(
-                HttpPolicyExtensions
-                    .HandleTransientHttpError()
-                    .OrResult(msg => msg.StatusCode == System.Net.HttpStatusCode.NotFound)
-                    .WaitAndRetryAsync(4, retry => TimeSpan.FromSeconds(Math.Pow(2, retry)))
-            );
+                }).AddStandardResilienceHandler();
 
+        services.AddSingleton<IYnabApi, YnabApi>();
         services.AddSingleton<IBudgetQueryService, BudgetQueryService>();
         services.AddSingleton<ICategoryQueryService, CategoryQueryService>();
         services.AddSingleton<IAccountQueryService, AccountQueryService>();

--- a/ynab.api/ServiceCollectionExtensions.cs
+++ b/ynab.api/ServiceCollectionExtensions.cs
@@ -1,7 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using Polly;
-using Polly.Extensions.Http;
-using Refit;
 using YnabApi.Account;
 using YnabApi.Budget;
 using YnabApi.Category;
@@ -20,24 +17,6 @@ public static class YnabApiServiceCollectionExtensions
     {
         if (string.IsNullOrWhiteSpace("token"))
             throw new ArgumentException("Valid YNAB API token is required", nameof(token));
-
-     //   services.AddRefitClient<IYnabApi>()
-     //       .ConfigureHttpClient(
-     //           httpClient =>
-     //           {
-     //               var endpoint = YnabOptions.Endpoint;
-     //               var version = YnabOptions.Version;
-
-     //               httpClient.BaseAddress = new Uri($"{endpoint}/{version}");
-     //               httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
-     //           }
-     //       )
-     //       .AddPolicyHandler(
-     //           HttpPolicyExtensions
-     //               .HandleTransientHttpError()
-     //               .OrResult(msg => msg.StatusCode == System.Net.HttpStatusCode.NotFound)
-     //               .WaitAndRetryAsync(4, retry => TimeSpan.FromSeconds(Math.Pow(2, retry)))
-     //       );
 
         services.AddHttpClient(nameof(YnabApi))
             .ConfigureHttpClient(

--- a/ynab.api/YnabApi.cs
+++ b/ynab.api/YnabApi.cs
@@ -1,0 +1,81 @@
+using System.Diagnostics;
+using System.Net.Http.Json;
+using YnabApi.Account;
+using YnabApi.Budget;
+using YnabApi.Category;
+
+namespace YnabApi;
+
+public class YnabApi : IYnabApi
+{
+    private readonly HttpClient _httpClient;
+    public YnabApi(IHttpClientFactory httpClientFactory)
+    {
+        _httpClient = httpClientFactory.CreateClient(nameof(YnabApi));
+    }
+        
+    public async Task<QueryResponse<BudgetResponse>> GetBudgetsAsync()
+    {
+        var path = "budgets";
+        var budgets = new QueryResponse<BudgetResponse>();
+        try
+        {
+            budgets = await _httpClient.GetFromJsonAsync<QueryResponse<BudgetResponse>>(path) ?? budgets;
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine(ex.ToString());
+        }
+
+        return budgets;
+    }
+
+    public async Task<QueryResponse<BudgetMonthResponse>> GetBudgetMonthAsync(string id, string month)
+    {
+        var path = $"budgets/{id}/months/{month}";
+        var budget = new QueryResponse<BudgetMonthResponse>();
+        try
+        {
+            budget = await _httpClient.GetFromJsonAsync<QueryResponse<BudgetMonthResponse>>(path) ?? budget;
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine(ex.ToString());
+        }
+            
+        return budget;
+    }
+
+    public async Task<QueryResponse<CategoryResponse>> GetBudgetCategoriesAsync(string id)
+    {
+
+        var path = $"budgets/{id}/categories";
+        var categories = new QueryResponse<CategoryResponse>();
+        try
+        {
+            categories = await _httpClient.GetFromJsonAsync<QueryResponse<CategoryResponse>>(path) ?? categories;
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine(ex.ToString());
+        }
+
+        return categories;
+    }
+
+    public async Task<QueryResponse<AccountResponse>> GetBudgetAccountsAsync(string id)
+    {
+
+        var path = $"budgets/{id}/accounts";
+        var accounts = new QueryResponse<AccountResponse>();
+        try
+        {
+            accounts = await _httpClient.GetFromJsonAsync<QueryResponse<AccountResponse>>(path) ?? accounts;
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine(ex.ToString());
+        }
+        return accounts;
+    }
+}

--- a/ynab.api/YnabApi.csproj
+++ b/ynab.api/YnabApi.csproj
@@ -16,8 +16,6 @@
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
     <PackageReference Include="Polly" Version="8.5.0" />
-    <PackageReference Include="Refit" Version="8.0.0" />
-    <PackageReference Include="Refit.HttpClientFactory" Version="8.0.0" />
   </ItemGroup>
 
 </Project>

--- a/ynab.api/YnabApi.csproj
+++ b/ynab.api/YnabApi.csproj
@@ -14,6 +14,7 @@
   
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" Version="9.0.0" />
     <PackageReference Include="Polly" Version="8.5.0" />
     <PackageReference Include="Refit" Version="8.0.0" />
     <PackageReference Include="Refit.HttpClientFactory" Version="8.0.0" />


### PR DESCRIPTION
Fixes #37 and may address issues with aot trimming, but that will need further investigation.

Mainly removes refit's auto generated Http classes with hand-built classes. They are not particularly complicated anyway so the work it was saving was minimal. It also prevented trimming due to Refit not being compatible with trimming. This fix hopefully brings aot trimmed compilation further towards reality.