### PR TITLE
Trim filesize by using trimmed aot compliation

### DIFF
--- a/ynab.api/Account/Account.cs
+++ b/ynab.api/Account/Account.cs
@@ -4,6 +4,7 @@ namespace YnabApi.Account
 {
     public class Account
     {
+        [JsonPropertyName("id")]
         public Guid Id { get; set; }
 
         [JsonPropertyName("balance")]

--- a/ynab.api/Budget/Budget.cs
+++ b/ynab.api/Budget/Budget.cs
@@ -32,6 +32,7 @@ namespace YnabApi.Budget
         [JsonPropertyName("name")]
         public string Name { get; init; } = string.Empty;
 
+        [JsonPropertyName("id")]
         public Guid Id { get; init; }
         
         public BudgetType Type { get; init; } = BudgetType.UserBudget;

--- a/ynab.api/YnabApi.cs
+++ b/ynab.api/YnabApi.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Net.Http.Json;
+using System.Text.Json;
 using YnabApi.Account;
 using YnabApi.Budget;
 using YnabApi.Category;
@@ -20,11 +21,11 @@ public class YnabApi : IYnabApi
         var budgets = new QueryResponse<BudgetResponse>();
         try
         {
-            budgets = await _httpClient.GetFromJsonAsync<QueryResponse<BudgetResponse>>(path) ?? budgets;
+            budgets = await _httpClient.GetFromJsonAsync<QueryResponse<BudgetResponse>>(path, YnabJsonSerializerContext.Default.QueryResponseBudgetResponse) ?? budgets;
         }
         catch (Exception ex)
         {
-            Debug.WriteLine(ex.ToString());
+            Console.WriteLine(ex.ToString());
         }
 
         return budgets;
@@ -36,11 +37,11 @@ public class YnabApi : IYnabApi
         var budget = new QueryResponse<BudgetMonthResponse>();
         try
         {
-            budget = await _httpClient.GetFromJsonAsync<QueryResponse<BudgetMonthResponse>>(path) ?? budget;
+            budget = await _httpClient.GetFromJsonAsync<QueryResponse<BudgetMonthResponse>>(path, YnabJsonSerializerContext.Default.QueryResponseBudgetMonthResponse) ?? budget;
         }
         catch (Exception ex)
         {
-            Debug.WriteLine(ex.ToString());
+            Console.WriteLine(ex.ToString());
         }
             
         return budget;
@@ -53,11 +54,11 @@ public class YnabApi : IYnabApi
         var categories = new QueryResponse<CategoryResponse>();
         try
         {
-            categories = await _httpClient.GetFromJsonAsync<QueryResponse<CategoryResponse>>(path) ?? categories;
+            categories = await _httpClient.GetFromJsonAsync<QueryResponse<CategoryResponse>>(path, YnabJsonSerializerContext.Default.QueryResponseCategoryResponse) ?? categories;
         }
         catch (Exception ex)
         {
-            Debug.WriteLine(ex.ToString());
+            Console.WriteLine(ex.ToString());
         }
 
         return categories;
@@ -70,11 +71,11 @@ public class YnabApi : IYnabApi
         var accounts = new QueryResponse<AccountResponse>();
         try
         {
-            accounts = await _httpClient.GetFromJsonAsync<QueryResponse<AccountResponse>>(path) ?? accounts;
+            accounts = await _httpClient.GetFromJsonAsync<QueryResponse<AccountResponse>>(path, YnabJsonSerializerContext.Default.QueryResponseAccountResponse) ?? accounts;
         }
         catch (Exception ex)
         {
-            Debug.WriteLine(ex.ToString());
+            Console.WriteLine(ex.ToString());
         }
         return accounts;
     }

--- a/ynab.api/YnabApi.csproj
+++ b/ynab.api/YnabApi.csproj
@@ -10,7 +10,6 @@
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <DebugSymbols>False</DebugSymbols>
     <DebugType>None</DebugType>
-    <PublishTrimmed>True</PublishTrimmed>
   </PropertyGroup>
   
   <ItemGroup>

--- a/ynab.api/YnabApi.csproj
+++ b/ynab.api/YnabApi.csproj
@@ -10,6 +10,7 @@
   <PropertyGroup Condition="'$(Configuration)'=='Release'">
     <DebugSymbols>False</DebugSymbols>
     <DebugType>None</DebugType>
+    <PublishTrimmed>True</PublishTrimmed>
   </PropertyGroup>
   
   <ItemGroup>

--- a/ynab.api/YnabJsonSerializerContext.cs
+++ b/ynab.api/YnabJsonSerializerContext.cs
@@ -1,0 +1,26 @@
+using System.Text.Json.Serialization;
+using YnabApi.Account;
+using YnabApi.Budget;
+using YnabApi.Category;
+
+namespace YnabApi;
+
+[JsonSerializable(typeof(QueryResponse<BudgetResponse>))]
+[JsonSerializable(typeof(BudgetResponse))]
+[JsonSerializable(typeof(Budget.Budget))]
+
+[JsonSerializable(typeof(QueryResponse<CategoryResponse>))]
+[JsonSerializable(typeof(CategoryResponse))]
+[JsonSerializable(typeof(Category.Category))]
+[JsonSerializable(typeof(CategoryGroup))]
+
+[JsonSerializable(typeof(QueryResponse<AccountResponse>))]
+[JsonSerializable(typeof(AccountResponse))]
+[JsonSerializable(typeof(Account.Account))]
+
+[JsonSerializable(typeof(QueryResponse<BudgetMonthResponse>))]
+[JsonSerializable(typeof(BudgetMonthResponse))]
+[JsonSerializable(typeof(BudgetMonth))]
+internal partial class YnabJsonSerializerContext : JsonSerializerContext
+{
+}

--- a/ynac.cli/Commands/BudgetCommand.cs
+++ b/ynac.cli/Commands/BudgetCommand.cs
@@ -6,60 +6,60 @@ using Spectre.Console.Cli;
 
 namespace ynac.Commands;
 
-public sealed class BudgetCommand : AsyncCommand<BudgetCommand.Settings>
+public sealed class BudgetCommand : AsyncCommand<BudgetCommandSettings>
 {
-    public sealed class Settings : CommandSettings
-    {
-        [Description("The budget name to filter to. If more than one budget matches the filter string, a selection prompt will be presented.")]
-        [CommandArgument(0, "[budgetFilter]")]
-        public string? BudgetFilter { get; init; }
-
-        [Description("The category name to filter to. Will all first categorites containing this string")]
-        [CommandArgument(1, "[categoryFilter]")]
-        public string? CategoryFilter { get; init; }
-		
-        [Description("Open the budget on the web. If a budget filter is applied, the found budget will be opened. " +
-                     "If a filter is not applied, the budget will be opened after one is selected. Cannot be used with" +
-                     "--last-used flag.")]
-        [CommandOption("-o|--open")]
-        [DefaultValue(false)]
-        public bool Open { get; set; }
-        
-        [Description("Show goal progress indicators in the view (work in progress, may not properly reflect some goals. " +
-                     "Additionally, text formatting is not consistent with the non-goal display")]
-        [CommandOption("-g|--show-goals")]
-        [DefaultValue(false)]
-        public bool ShowGoals { get; init; }
-        
-        [Description("Default to showing the last used budget, will ignore the budget filter, and the --open flag. " +
-                     "Relies on the YNAB API to determine the last used budget. " +
-                     "If the API token you are using has not accessed a budget previously, the command will fail. " +
-                     "Cannot be used with the --open flag.")]
-        [CommandOption("-u|--last-used")]
-        [DefaultValue(false)]
-        public bool PullLastUsed { get; init; }
-    }
-
-    public override async Task<int> ExecuteAsync(CommandContext context, Settings settings)
+    public override async Task<int> ExecuteAsync(CommandContext context, BudgetCommandSettings settings)
     {
         if (settings.Open && settings.PullLastUsed)
         {
-            AnsiConsole.Markup("[red]Cannot use both --open and --last-used flags together. --open flag will be ignored[/]\n");
+            AnsiConsole.Markup("[red]Cannot use both --open and --last-used flags together. --open flag will be ignored[/]\n"); 
             settings.Open = false;
         }
-        
+                
         var configurationRoot =  new ConfigurationBuilder()
             .AddIniFile(Constants.ConfigFileLocation) 
             .AddEnvironmentVariables()
             .Build();
-        
+                
         var token = configurationRoot[Constants.YnabApiSectionTokenKey];
         token = TokenHandler.HandleMissingToken(token);
-        
+                
         var ynacProvider = YnacConsoleProvider.BuildYnacServices(token);
-        
+                
         var ynacConsole = ynacProvider.GetRequiredService<IYnacConsole>();
         await ynacConsole.RunAsync(settings);
-        return 0;
+        return 0; 
     }
+}
+
+public sealed class BudgetCommandSettings : CommandSettings
+{
+    [Description("The budget name to filter to. If more than one budget matches the filter string, a selection prompt will be presented.")]
+    [CommandArgument(0, "[budgetFilter]")]
+    public string? BudgetFilter { get; init; }
+
+    [Description("The category name to filter to. Will all first categorites containing this string")]
+    [CommandArgument(1, "[categoryFilter]")]
+    public string? CategoryFilter { get; init; }
+		
+    [Description("Open the budget on the web. If a budget filter is applied, the found budget will be opened. " +
+                 "If a filter is not applied, the budget will be opened after one is selected. Cannot be used with" +
+                 "--last-used flag.")]
+    [CommandOption("-o|--open")]
+    [DefaultValue(false)]
+    public bool Open { get; set; }
+        
+    [Description("Show goal progress indicators in the view (work in progress, may not properly reflect some goals. " +
+                 "Additionally, text formatting is not consistent with the non-goal display")]
+    [CommandOption("-g|--show-goals")]
+    [DefaultValue(false)]
+    public bool ShowGoals { get; init; }
+        
+    [Description("Default to showing the last used budget, will ignore the budget filter, and the --open flag. " +
+                 "Relies on the YNAB API to determine the last used budget. " +
+                 "If the API token you are using has not accessed a budget previously, the command will fail. " +
+                 "Cannot be used with the --open flag.")]
+    [CommandOption("-u|--last-used")]
+    [DefaultValue(false)]
+    public bool PullLastUsed { get; init; }
 }

--- a/ynac.cli/IYnacConsole.cs
+++ b/ynac.cli/IYnacConsole.cs
@@ -4,5 +4,5 @@ namespace ynac;
 
 public interface IYnacConsole
 {
-    public Task RunAsync(BudgetCommand.Settings settings);
+    public Task RunAsync(BudgetCommandSettings settings);
 }

--- a/ynac.cli/Program.cs
+++ b/ynac.cli/Program.cs
@@ -1,7 +1,32 @@
-﻿using Spectre.Console.Cli;
-using ynac;
+﻿using System.Diagnostics.CodeAnalysis;
+using Spectre.Console.Cli;
 using ynac.Commands;
 
+
+namespace ynac;
+
+internal class Program
+{
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(BudgetCommand))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, typeof(BudgetCommandSettings))]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Spectre.Console.Cli.ExplainCommand", "Spectre.Console.Cli")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Spectre.Console.Cli.VersionCommand", "Spectre.Console.Cli")]
+    [DynamicDependency(DynamicallyAccessedMemberTypes.All, "Spectre.Console.Cli.XmlDocCommand", "Spectre.Console.Cli")]
+    public static async Task Main(string[] args)
+    {
+        await InitConfigFile(); 
+       
+        var app = new CommandApp<BudgetCommand>();
+        await app.RunAsync(args);
+    }
+
+
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+    private static async Task InitConfigFile()
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+    {
+        // create config file if it doesn't exist, but only in release mode. This was done for testing purposes.
+        // can likely do this with a flag in the future
 #if ! DEBUG
 if(!File.Exists(Constants.ConfigFileLocation))
 {
@@ -12,6 +37,5 @@ if(!File.Exists(Constants.ConfigFileLocation))
     await streamWriter.WriteLineAsync($"{Constants.TokenString}=\"{Constants.DefaultTokenString}\"");
 }
 #endif
-
-var app = new CommandApp<BudgetCommand>();
-await app.RunAsync(args);
+    }
+}

--- a/ynac.cli/YnacConsole.cs
+++ b/ynac.cli/YnacConsole.cs
@@ -16,7 +16,7 @@ internal class YnacConsole(
 	IEnumerable<IBudgetAction> budgetActions
 ) : IYnacConsole
 {
-	public async Task RunAsync(BudgetCommand.Settings settings) 
+	public async Task RunAsync(BudgetCommandSettings settings) 
 	{
 		WriteHeaderRule("[bold]You Need A Console[/]");
 
@@ -65,7 +65,7 @@ internal class YnacConsole(
 		}
 	}
 
-	private static void GenerateCategoryTable(IReadOnlyCollection<CategoryGroup> categoryGroups, BudgetCommand.Settings settings, Table table)
+	private static void GenerateCategoryTable(IReadOnlyCollection<CategoryGroup> categoryGroups, BudgetCommandSettings settings, Table table)
 	{
 		foreach (var categoryGroup in categoryGroups)
 		{

--- a/ynac.cli/ynac.csproj
+++ b/ynac.cli/ynac.csproj
@@ -7,8 +7,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>ynac</RootNamespace>
-    <TrimSingleWarn>False</TrimSingleWarn>
     <LangVersion>13</LangVersion>
+    <TrimSingleWarn>False</TrimSingleWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/ynac.cli/ynac.csproj
+++ b/ynac.cli/ynac.csproj
@@ -13,6 +13,7 @@
     <DebugSymbols>False</DebugSymbols>
     <DebugType>None</DebugType>
     <PublishSingleFile>true</PublishSingleFile>
+    <PublishTrimmed>True</PublishTrimmed>
   </PropertyGroup>
   
   <ItemGroup>

--- a/ynac.cli/ynac.csproj
+++ b/ynac.cli/ynac.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+<!--	https://learn.microsoft.com/en-us/dotnet/core/deploying/trimming/trimming-options?pivots=dotnet-8-0 -->
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -6,6 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>ynac</RootNamespace>
+    <TrimSingleWarn>False</TrimSingleWarn>
     <LangVersion>13</LangVersion>
   </PropertyGroup>
 
@@ -13,6 +15,7 @@
     <DebugSymbols>False</DebugSymbols>
     <DebugType>None</DebugType>
     <PublishSingleFile>true</PublishSingleFile>
+    <SelfContained>true</SelfContained>
     <PublishTrimmed>True</PublishTrimmed>
   </PropertyGroup>
   


### PR DESCRIPTION
Fixes #43 

File size has been reduced from over 65MB to less than 20MB. 
Refit has been removed and replaced with custom concrete implementations.
System.Text.Json has been modified to do source generation for Json conversions.
Spectre Console is not trimmable so there is still potential for a smaller file. The workaround is to inform the trimmer to ignore Spectre.Console trimming.

Tested to work on MacOS and Windows.

<img width="405" alt="image" src="https://github.com/user-attachments/assets/6cb0f1b7-14be-4e80-b9bd-453ff221b690" />

Linux test will be performed before PR is approved.