### PR TITLE
Structure changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -397,3 +397,4 @@ FodyWeavers.xsd
 # JetBrains Rider
 *.sln.iml
 .idea/
+.DS_Store

--- a/ynab/Account/Account.cs
+++ b/ynab/Account/Account.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace YnabApi.Account
+namespace ynab.Account
 {
     public class Account
     {

--- a/ynab/Account/AccountQueryService.cs
+++ b/ynab/Account/AccountQueryService.cs
@@ -1,4 +1,4 @@
-﻿namespace YnabApi.Account
+﻿namespace ynab.Account
 {
     public class AccountQueryService(IYnabApi ynabApi) : IAccountQueryService
     {

--- a/ynab/Account/AccountQueryService.cs
+++ b/ynab/Account/AccountQueryService.cs
@@ -1,12 +1,12 @@
 ﻿namespace ynab.Account
 {
-    public class AccountQueryService(IYnabApi ynabApi) : IAccountQueryService
+    public class AccountQueryService(IBudgetApi budgetApi) : IAccountQueryService
     {
         public async Task<IReadOnlyCollection<Account>> GetBudgetAccounts(Budget.Budget selectedBudget)
         {
-            var response = await ynabApi.GetBudgetAccountsAsync(selectedBudget.BudgetId);
+            var response = await budgetApi.GetBudgetAccountsAsync(selectedBudget.BudgetId);
 
-            return response.Data?.Accounts ?? new []{ new Account() };
+            return response.Data?.Accounts ?? [new Account()];
         }
     }
 }

--- a/ynab/Account/AccountResponse.cs
+++ b/ynab/Account/AccountResponse.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace YnabApi.Account
+namespace ynab.Account
 {
     public class AccountResponse
     {

--- a/ynab/Account/IAccountQueryService.cs
+++ b/ynab/Account/IAccountQueryService.cs
@@ -1,4 +1,4 @@
-namespace YnabApi.Account;
+namespace ynab.Account;
 
 public interface IAccountQueryService
 {

--- a/ynab/Budget/Budget.cs
+++ b/ynab/Budget/Budget.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace YnabApi.Budget
+namespace ynab.Budget
 {
     public class Budget
     {

--- a/ynab/Budget/BudgetMonth.cs
+++ b/ynab/Budget/BudgetMonth.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace YnabApi.Budget
+namespace ynab.Budget
 {
     public class BudgetMonth
     {

--- a/ynab/Budget/BudgetQueryService.cs
+++ b/ynab/Budget/BudgetQueryService.cs
@@ -10,7 +10,7 @@ namespace ynab.Budget
         public bool ShowDeletedCategories { get; set; }
     }
 
-    public class BudgetQueryService(IYnabApi ynabApi) : IBudgetQueryService
+    public class BudgetQueryService(IBudgetApi budgetApi) : IBudgetQueryService
     {
         private BudgetCategorySearchOptions _options = new();
         private void Configure(Action<BudgetCategorySearchOptions> budgetAction)
@@ -38,7 +38,7 @@ namespace ynab.Budget
         {
             ArgumentNullException.ThrowIfNull(_options.SelectedBudget, nameof(_options.SelectedBudget));
             
-            var response = await ynabApi.GetBudgetCategoriesAsync(_options.SelectedBudget.BudgetId);
+            var response = await budgetApi.GetBudgetCategoriesAsync(_options.SelectedBudget.BudgetId);
 
             // first group is the "Internal Master Category" used by YNAB, so we skip it
             var filteredGroups = response.Data?.Groups?
@@ -59,7 +59,7 @@ namespace ynab.Budget
         
         public async Task<IReadOnlyCollection<Budget>> GetBudgets()
         {
-            var response = await ynabApi.GetBudgetsAsync();
+            var response = await budgetApi.GetBudgetsAsync();
 
             var budgets = response.Data?.Budgets;
             
@@ -81,7 +81,7 @@ namespace ynab.Budget
             }
 
             var dateString = dateModified.ToString("yyyy-MM-01");
-            var response = await ynabApi.GetBudgetMonthAsync(budget.BudgetId, dateString);
+            var response = await budgetApi.GetBudgetMonthAsync(budget.BudgetId, dateString);
         
             return response.Data?.Budget ?? new BudgetMonth();
         } 

--- a/ynab/Budget/BudgetQueryService.cs
+++ b/ynab/Budget/BudgetQueryService.cs
@@ -1,6 +1,6 @@
-﻿using YnabApi.Category;
+﻿using ynab.Category;
 
-namespace YnabApi.Budget
+namespace ynab.Budget
 {
     public record BudgetCategorySearchOptions
     {

--- a/ynab/Budget/BudgetResponse.cs
+++ b/ynab/Budget/BudgetResponse.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace YnabApi.Budget
+namespace ynab.Budget
 {
     public class BudgetResponse
     {

--- a/ynab/Budget/IBudgetQueryService.cs
+++ b/ynab/Budget/IBudgetQueryService.cs
@@ -1,6 +1,6 @@
-﻿using YnabApi.Category;
+﻿using ynab.Category;
 
-namespace YnabApi.Budget
+namespace ynab.Budget
 {
     public interface IBudgetQueryService
     {

--- a/ynab/BudgetApi.cs
+++ b/ynab/BudgetApi.cs
@@ -5,12 +5,12 @@ using ynab.Category;
 
 namespace ynab;
 
-public class YnabApi : IYnabApi
+internal class BudgetApi : IBudgetApi
 {
     private readonly HttpClient _httpClient;
-    public YnabApi(IHttpClientFactory httpClientFactory)
+    public BudgetApi(IHttpClientFactory httpClientFactory)
     {
-        _httpClient = httpClientFactory.CreateClient(nameof(YnabApi));
+        _httpClient = httpClientFactory.CreateClient(nameof(BudgetApi));
     }
         
     public async Task<QueryResponse<BudgetResponse>> GetBudgetsAsync()

--- a/ynab/Category/Category.cs
+++ b/ynab/Category/Category.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace YnabApi.Category
+namespace ynab.Category
 {
     public class Category
     {

--- a/ynab/Category/CategoryGroup.cs
+++ b/ynab/Category/CategoryGroup.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace YnabApi.Category
+namespace ynab.Category
 {
     public class CategoryGroup
     {

--- a/ynab/Category/CategoryQueryService.cs
+++ b/ynab/Category/CategoryQueryService.cs
@@ -1,10 +1,10 @@
 ﻿namespace ynab.Category
 {
-    public class CategoryQueryService(IYnabApi ynabApi) : ICategoryQueryService
+    public class CategoryQueryService(IBudgetApi budgetApi) : ICategoryQueryService
     {
         public async Task<IReadOnlyCollection<CategoryGroup>> GetBudgetCategoriesAsync(Budget.Budget budget)
         {
-            var response = await ynabApi.GetBudgetCategoriesAsync(budget.BudgetId);
+            var response = await budgetApi.GetBudgetCategoriesAsync(budget.BudgetId);
             
             return response.Data?.Groups ?? new []{ new CategoryGroup() };
         }

--- a/ynab/Category/CategoryQueryService.cs
+++ b/ynab/Category/CategoryQueryService.cs
@@ -1,4 +1,4 @@
-﻿namespace YnabApi.Category
+﻿namespace ynab.Category
 {
     public class CategoryQueryService(IYnabApi ynabApi) : ICategoryQueryService
     {

--- a/ynab/Category/CategoryResponse.cs
+++ b/ynab/Category/CategoryResponse.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace YnabApi.Category
+namespace ynab.Category
 {
     public class CategoryResponse
     {

--- a/ynab/Category/ICategoryQueryService.cs
+++ b/ynab/Category/ICategoryQueryService.cs
@@ -1,4 +1,4 @@
-namespace YnabApi.Category;
+namespace ynab.Category;
 
 public interface ICategoryQueryService
 {

--- a/ynab/IBudgetApi.cs
+++ b/ynab/IBudgetApi.cs
@@ -4,7 +4,7 @@ using ynab.Category;
 
 namespace ynab
 {
-    public interface IYnabApi
+    public interface IBudgetApi
     {
         internal Task<QueryResponse<BudgetResponse>> GetBudgetsAsync();
         internal Task<QueryResponse<BudgetMonthResponse>> GetBudgetMonthAsync(string id, string month);

--- a/ynab/IYnabApi.cs
+++ b/ynab/IYnabApi.cs
@@ -1,8 +1,8 @@
-﻿using YnabApi.Account;
-using YnabApi.Budget;
-using YnabApi.Category;
+﻿using ynab.Account;
+using ynab.Budget;
+using ynab.Category;
 
-namespace YnabApi
+namespace ynab
 {
     public interface IYnabApi
     {

--- a/ynab/QueryResponse.cs
+++ b/ynab/QueryResponse.cs
@@ -1,6 +1,6 @@
 ﻿using System.Text.Json.Serialization;
 
-namespace YnabApi
+namespace ynab
 {
     public class QueryResponse<T>
     {

--- a/ynab/ServiceCollectionExtensions.cs
+++ b/ynab/ServiceCollectionExtensions.cs
@@ -1,9 +1,9 @@
 using Microsoft.Extensions.DependencyInjection;
-using YnabApi.Account;
-using YnabApi.Budget;
-using YnabApi.Category;
+using ynab.Account;
+using ynab.Budget;
+using ynab.Category;
 
-namespace YnabApi;
+namespace ynab;
 
 internal static class YnabOptions
 {

--- a/ynab/ServiceCollectionExtensions.cs
+++ b/ynab/ServiceCollectionExtensions.cs
@@ -18,7 +18,7 @@ public static class YnabApiServiceCollectionExtensions
         if (string.IsNullOrWhiteSpace("token"))
             throw new ArgumentException("Valid YNAB API token is required", nameof(token));
 
-        services.AddHttpClient(nameof(YnabApi))
+        services.AddHttpClient(nameof(BudgetApi))
             .ConfigureHttpClient(
                 httpClient =>
                 {
@@ -29,7 +29,7 @@ public static class YnabApiServiceCollectionExtensions
                     httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {token}");
                 }).AddStandardResilienceHandler();
 
-        services.AddSingleton<IYnabApi, YnabApi>();
+        services.AddSingleton<IBudgetApi, BudgetApi>();
         services.AddSingleton<IBudgetQueryService, BudgetQueryService>();
         services.AddSingleton<ICategoryQueryService, CategoryQueryService>();
         services.AddSingleton<IAccountQueryService, AccountQueryService>();

--- a/ynab/YnabApi.cs
+++ b/ynab/YnabApi.cs
@@ -1,11 +1,9 @@
-using System.Diagnostics;
 using System.Net.Http.Json;
-using System.Text.Json;
-using YnabApi.Account;
-using YnabApi.Budget;
-using YnabApi.Category;
+using ynab.Account;
+using ynab.Budget;
+using ynab.Category;
 
-namespace YnabApi;
+namespace ynab;
 
 public class YnabApi : IYnabApi
 {

--- a/ynab/YnabJsonSerializerContext.cs
+++ b/ynab/YnabJsonSerializerContext.cs
@@ -1,9 +1,9 @@
 using System.Text.Json.Serialization;
-using YnabApi.Account;
-using YnabApi.Budget;
-using YnabApi.Category;
+using ynab.Account;
+using ynab.Budget;
+using ynab.Category;
 
-namespace YnabApi;
+namespace ynab;
 
 [JsonSerializable(typeof(QueryResponse<BudgetResponse>))]
 [JsonSerializable(typeof(BudgetResponse))]

--- a/ynab/ynab.csproj
+++ b/ynab/ynab.csproj
@@ -5,6 +5,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <LangVersion>13</LangVersion>
+    <AssemblyName>ynab</AssemblyName>
+    <RootNamespace>ynab</RootNamespace>
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(Configuration)'=='Release'">

--- a/ynac.cli/BudgetSelection/BudgetPrompter.cs
+++ b/ynac.cli/BudgetSelection/BudgetPrompter.cs
@@ -1,4 +1,4 @@
-using YnabApi.Budget;
+using ynab.Budget;
 
 namespace ynac.BudgetSelection;
 

--- a/ynac.cli/BudgetSelection/BudgetSelector.cs
+++ b/ynac.cli/BudgetSelection/BudgetSelector.cs
@@ -1,4 +1,4 @@
-using YnabApi.Budget;
+using ynab.Budget;
 
 namespace ynac.BudgetSelection;
 

--- a/ynac.cli/BudgetSelection/IBudgetPrompter.cs
+++ b/ynac.cli/BudgetSelection/IBudgetPrompter.cs
@@ -1,4 +1,4 @@
-using YnabApi.Budget;
+using ynab.Budget;
 
 namespace ynac.BudgetSelection;
 

--- a/ynac.cli/BudgetSelection/IBudgetSelector.cs
+++ b/ynac.cli/BudgetSelection/IBudgetSelector.cs
@@ -1,4 +1,4 @@
-using YnabApi.Budget;
+using ynab.Budget;
 
 namespace ynac.BudgetSelection;
 

--- a/ynac.cli/OSFeatures/BudgetBrowserOpener.cs
+++ b/ynac.cli/OSFeatures/BudgetBrowserOpener.cs
@@ -1,4 +1,4 @@
-using YnabApi.Budget;
+using ynab.Budget;
 
 namespace ynac.OSFeatures;
 

--- a/ynac.cli/OSFeatures/IBudgetBrowserOpener.cs
+++ b/ynac.cli/OSFeatures/IBudgetBrowserOpener.cs
@@ -1,4 +1,4 @@
-using YnabApi.Budget;
+using ynab.Budget;
 
 namespace ynac.OSFeatures;
 

--- a/ynac.cli/YnacConsole.cs
+++ b/ynac.cli/YnacConsole.cs
@@ -1,7 +1,7 @@
 using Spectre.Console;
 using Spectre.Console.Rendering;
-using YnabApi.Budget;
-using YnabApi.Category;
+using ynab.Budget;
+using ynab.Category;
 using ynac.BudgetActions;
 using ynac.BudgetSelection;
 using ynac.Commands;

--- a/ynac.cli/YnacConsoleProvider.cs
+++ b/ynac.cli/YnacConsoleProvider.cs
@@ -1,7 +1,6 @@
 using System.Runtime.InteropServices;
 using Microsoft.Extensions.DependencyInjection;
-using Spectre.Console;
-using YnabApi;
+using ynab;
 using ynac.BudgetActions;
 using ynac.BudgetSelection;
 using ynac.OSFeatures;

--- a/ynac.cli/ynac.csproj
+++ b/ynac.cli/ynac.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ynab.api\YnabApi.csproj" />
+    <ProjectReference Include="..\ynab\ynab.csproj" />
   </ItemGroup>
 
 </Project>

--- a/ynac.sln
+++ b/ynac.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YnabApi", "ynab.api\YnabApi.csproj", "{781C9426-2A98-4973-A75C-2AD018DE8F98}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ynab", "ynab\ynab.csproj", "{781C9426-2A98-4973-A75C-2AD018DE8F98}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ynac", "ynac.cli\ynac.csproj", "{628CFF60-8D0F-44AB-A660-30BB1E1D4CDC}"
 EndProject

--- a/ynac.tests/BudgetSelection/BudgetPrompterTests.cs
+++ b/ynac.tests/BudgetSelection/BudgetPrompterTests.cs
@@ -2,7 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NSubstitute;
 using Spectre.Console;
-using YnabApi.Budget;
+using ynab.Budget;
 using ynac.BudgetSelection;
 
 namespace ynac.Tests.BudgetSelection;


### PR DESCRIPTION
repeated names in files and namespace was confusing e.g. `YnabApi.IYnabApi`

Namespace for ynab API specific project has moved to simply `ynab`. Ynac namespaces have remained as `ynac.cli` and `ynac.tests`. This may be confusing too but it isn't to me at least.

Changed `YnabApi` to `BudgetApi`, though after the namespace change this may not be entirely necessary. Will revisit if it feels like this is still confusing.

Full reference for IBudgetApi is now `ynab.IBudgetApi`. To follow the convention of other projects, I might eventually rename it to `ynab.api.IBudgetApi`