### PR TITLE
move config file template to embedded resource

### DIFF
--- a/ynac.cli/Constants.cs
+++ b/ynac.cli/Constants.cs
@@ -12,6 +12,7 @@ public static class Constants
     internal static string YnabRootUrl => "https://app.ynab.com/";
     internal static string BudgetRouteAffix => "/budget";
     internal static string ConfigFileLocation => "./config.ini";
+    internal static string ConfigFileTemplate => "ynac._res.config.template.ini";
     
     // The default string to check for in config.ini, do not edit here 
     internal static string DefaultTokenString => "put-your-token-here";

--- a/ynac.cli/TokenHandler.cs
+++ b/ynac.cli/TokenHandler.cs
@@ -4,9 +4,6 @@ namespace ynac;
 
 internal static class TokenHandler
 {
-    // warning is suppressed as this is used in Program.cs but
-    // preprocessor directive causes it to appear unused in debug
-    // ReSharper disable once MemberCanBePrivate.Global
     public static string HandleMissingToken(string? token)
     {
         if (string.IsNullOrWhiteSpace(token) || token == Constants.DefaultTokenString)

--- a/ynac.cli/_res/_DO_NOT_EDIT_THESE_FILES.md
+++ b/ynac.cli/_res/_DO_NOT_EDIT_THESE_FILES.md
@@ -1,0 +1,8 @@
+Files in this directory are resource files. 
+
+They are used as a template to create other files. 
+
+They should not be edited here unless the structure of the file has 
+changed and the template needs editing. 
+
+If the location of these files change, edit the embedded resource constants in Program.cs

--- a/ynac.cli/_res/config.template.ini
+++ b/ynac.cli/_res/config.template.ini
@@ -1,0 +1,2 @@
+[YnabApi]
+Token="put-your-token-here"

--- a/ynac.cli/ynac.csproj
+++ b/ynac.cli/ynac.csproj
@@ -30,13 +30,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="config.ini">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    <ProjectReference Include="..\ynab\ynab.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ynab\ynab.csproj" />
+    <EmbeddedResource Include="_res\config.template.ini" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #57 

moving this file will hopefully prevent developers from inadvertently committing sensitive info or unexpected defaults to their branches. the real config.ini will be created from this template on run if it doesn't already exist.

Tested to work with trimming and works as expected. File size not significantly affected.