### PR TITLE
feat: Persist API token from CLI to config.ini

### DIFF
--- a/ynac.cli/Commands/BudgetCommand.cs
+++ b/ynac.cli/Commands/BudgetCommand.cs
@@ -20,8 +20,9 @@ public sealed class BudgetCommand : AsyncCommand<BudgetCommandSettings>
             .AddIniFile(Constants.ConfigFileLocation) 
             .AddEnvironmentVariables()
             .Build();
-                
-        var token = configurationRoot[Constants.YnabApiSectionTokenKey];
+        
+        TokenHandler.MaybeSaveToken(settings.ApiToken);
+        var token = settings.ApiToken ?? configurationRoot[Constants.YnabApiSectionTokenKey];
         token = TokenHandler.HandleMissingToken(token);
                 
         var ynacProvider = YnacConsoleProvider.BuildYnacServices(token);
@@ -62,4 +63,8 @@ public sealed class BudgetCommandSettings : CommandSettings
     [CommandOption("-u|--last-used")]
     [DefaultValue(false)]
     public bool PullLastUsed { get; init; }
+
+    [Description("YNAB API Token. If provided on first run, the token will be saved to config.ini.")]
+    [CommandOption("-t|--api-token")]
+    public string? ApiToken { get; init; }
 }

--- a/ynac.cli/TokenHandler.cs
+++ b/ynac.cli/TokenHandler.cs
@@ -1,9 +1,57 @@
 using Spectre.Console;
+using System.IO;
+using System.Linq;
 
 namespace ynac;
 
 internal static class TokenHandler
 {
+    public static void MaybeSaveToken(string? tokenFromCommandLine)
+    {
+        if (string.IsNullOrWhiteSpace(tokenFromCommandLine) || tokenFromCommandLine == Constants.DefaultTokenString)
+        {
+            return;
+        }
+
+        var configFile = Constants.ConfigFileLocation;
+        var lines = File.Exists(configFile) ? File.ReadAllLines(configFile).ToList() : new List<string>();
+
+        var ynabApiSectionIndex = lines.FindIndex(line => line.Trim().Equals(Constants.YnabSectionKey, StringComparison.OrdinalIgnoreCase));
+
+        if (ynabApiSectionIndex == -1)
+        {
+            lines.Add(Constants.YnabSectionKey);
+            lines.Add($"{Constants.TokenString}={tokenFromCommandLine}");
+        }
+        else
+        {
+            var tokenIndex = -1;
+            for (var i = ynabApiSectionIndex + 1; i < lines.Count; i++)
+            {
+                if (lines[i].Trim().StartsWith("[")) // Reached another section
+                {
+                    break;
+                }
+                if (lines[i].Trim().StartsWith($"{Constants.TokenString}=", StringComparison.OrdinalIgnoreCase))
+                {
+                    tokenIndex = i;
+                    break;
+                }
+            }
+
+            if (tokenIndex != -1)
+            {
+                lines[tokenIndex] = $"{Constants.TokenString}={tokenFromCommandLine}";
+            }
+            else
+            {
+                lines.Insert(ynabApiSectionIndex + 1, $"{Constants.TokenString}={tokenFromCommandLine}");
+            }
+        }
+
+        File.WriteAllLines(configFile, lines);
+    }
+    
     public static string HandleMissingToken(string? token)
     {
         if (string.IsNullOrWhiteSpace(token) || token == Constants.DefaultTokenString)

--- a/ynac.tests/TokenHandlerTests.cs
+++ b/ynac.tests/TokenHandlerTests.cs
@@ -1,5 +1,223 @@
-﻿namespace ynac.Tests;
+using Xunit;
+using System.IO;
+using ynac; // For TokenHandler and Constants
+using System.Linq;
+using System;
+using System.Collections.Generic;
 
-public class TokenHandlerTests
+namespace ynac.Tests
 {
+    public class TokenHandlerTests : IDisposable
+    {
+        private readonly string _testConfigFilePath;
+
+        public TokenHandlerTests()
+        {
+            // Constants.ConfigFileLocation is "./config.ini"
+            // Path.GetFullPath resolves this against the current working directory,
+            // which for xUnit tests is usually the test project's output directory (e.g., bin/Debug/netX.X)
+            _testConfigFilePath = Path.GetFullPath(Constants.ConfigFileLocation);
+            
+            // Ensure a clean state before each test
+            CleanUpTestConfigFile();
+        }
+
+        private void CleanUpTestConfigFile()
+        {
+            if (File.Exists(_testConfigFilePath))
+            {
+                File.Delete(_testConfigFilePath);
+            }
+        }
+
+        public void Dispose()
+        {
+            // Ensure a clean state after all tests in the class have run
+            CleanUpTestConfigFile();
+            GC.SuppressFinalize(this);
+        }
+
+        private void CreateTestConfigFile(string content)
+        {
+            // Ensure directory exists if ./config.ini implies a structure like that (though usually not for a simple filename)
+            Directory.CreateDirectory(Path.GetDirectoryName(_testConfigFilePath));
+            File.WriteAllText(_testConfigFilePath, content);
+        }
+
+        private List<string> ReadTestConfigFile()
+        {
+            if (!File.Exists(_testConfigFilePath))
+            {
+                return new List<string>();
+            }
+            return File.ReadAllLines(_testConfigFilePath).ToList();
+        }
+
+        [Fact]
+        public void MaybeSaveToken_SavesToken_WhenConfigFileDoesNotExistAndTokenIsValid()
+        {
+            string newToken = "test_token_123";
+
+            TokenHandler.MaybeSaveToken(newToken);
+
+            Assert.True(File.Exists(_testConfigFilePath), "Config file should be created.");
+            var lines = ReadTestConfigFile();
+            Assert.Contains(Constants.YnabSectionKey, lines);
+            Assert.Contains($"{Constants.TokenString}={newToken}", lines);
+        }
+
+        [Fact]
+        public void MaybeSaveToken_SavesToken_WhenConfigFileHasPlaceholderTokenAndTokenIsValid()
+        {
+            string initialContent = $"{Constants.YnabSectionKey}\n{Constants.TokenString}={Constants.DefaultTokenString}\n";
+            CreateTestConfigFile(initialContent);
+            string newToken = "test_token_456";
+
+            TokenHandler.MaybeSaveToken(newToken);
+
+            var lines = ReadTestConfigFile();
+            Assert.Contains(Constants.YnabSectionKey, lines);
+            Assert.Contains($"{Constants.TokenString}={newToken}", lines);
+            Assert.DoesNotContain($"{Constants.TokenString}={Constants.DefaultTokenString}", lines);
+        }
+
+        [Fact]
+        public void MaybeSaveToken_DoesNotSaveToken_WhenTokenIsEmptyAndConfigFileDoesNotExist()
+        {
+            TokenHandler.MaybeSaveToken("");
+
+            Assert.False(File.Exists(_testConfigFilePath), "Config file should not be created for empty token if it doesn't exist.");
+        }
+        
+        [Fact]
+        public void MaybeSaveToken_DoesNotAlterFile_WhenTokenIsEmptyAndConfigFileExists()
+        {
+            string existingToken = "existing_valid_token";
+            string initialContent = $"{Constants.YnabSectionKey}\n{Constants.TokenString}={existingToken}\n";
+            CreateTestConfigFile(initialContent);
+            long initialFileSize = new FileInfo(_testConfigFilePath).Length;
+
+            TokenHandler.MaybeSaveToken("");
+            
+            Assert.True(File.Exists(_testConfigFilePath));
+            var lines = ReadTestConfigFile();
+            Assert.Contains($"{Constants.TokenString}={existingToken}", lines);
+            long finalFileSize = new FileInfo(_testConfigFilePath).Length;
+            Assert.Equal(initialFileSize, finalFileSize); // Ensure file not touched
+        }
+
+
+        [Fact]
+        public void MaybeSaveToken_DoesNotSaveToken_WhenTokenIsWhitespaceAndConfigFileDoesNotExist()
+        {
+            TokenHandler.MaybeSaveToken("   ");
+
+            Assert.False(File.Exists(_testConfigFilePath), "Config file should not be created for whitespace token if it doesn't exist.");
+        }
+
+        [Fact]
+        public void MaybeSaveToken_DoesNotAlterFile_WhenTokenIsWhitespaceAndConfigFileExists()
+        {
+            string existingToken = "existing_valid_token";
+            string initialContent = $"{Constants.YnabSectionKey}\n{Constants.TokenString}={existingToken}\n";
+            CreateTestConfigFile(initialContent);
+            long initialFileSize = new FileInfo(_testConfigFilePath).Length;
+
+            TokenHandler.MaybeSaveToken("   ");
+
+            Assert.True(File.Exists(_testConfigFilePath));
+            var lines = ReadTestConfigFile();
+            Assert.Contains($"{Constants.TokenString}={existingToken}", lines);
+            long finalFileSize = new FileInfo(_testConfigFilePath).Length;
+            Assert.Equal(initialFileSize, finalFileSize);
+        }
+        
+        [Fact]
+        public void MaybeSaveToken_DoesNotSaveToken_WhenTokenIsDefaultPlaceholderAndConfigFileDoesNotExist()
+        {
+            TokenHandler.MaybeSaveToken(Constants.DefaultTokenString);
+
+            Assert.False(File.Exists(_testConfigFilePath), "Config file should not be created for default placeholder token if it doesn't exist.");
+        }
+
+        [Fact]
+        public void MaybeSaveToken_DoesNotAlterFile_WhenTokenIsDefaultPlaceholderAndConfigFileExists()
+        {
+            string existingToken = "existing_valid_token";
+            string initialContent = $"{Constants.YnabSectionKey}\n{Constants.TokenString}={existingToken}\n";
+            CreateTestConfigFile(initialContent);
+            long initialFileSize = new FileInfo(_testConfigFilePath).Length;
+
+            TokenHandler.MaybeSaveToken(Constants.DefaultTokenString);
+
+            Assert.True(File.Exists(_testConfigFilePath));
+            var lines = ReadTestConfigFile();
+            Assert.Contains($"{Constants.TokenString}={existingToken}", lines);
+            long finalFileSize = new FileInfo(_testConfigFilePath).Length;
+            Assert.Equal(initialFileSize, finalFileSize);
+        }
+
+        // Test scenario 6: Testing that a new valid token *overwrites* an existing user token.
+        // This reflects the current implementation's behavior where a token from CLI is prioritized for saving.
+        [Fact]
+        public void MaybeSaveToken_OverwritesToken_WhenConfigFileHasDifferentUserTokenAndTokenIsValid()
+        {
+            string existingUserToken = "existing_user_token";
+            string initialContent = $"{Constants.YnabSectionKey}\n{Constants.TokenString}={existingUserToken}\n";
+            CreateTestConfigFile(initialContent);
+            string newTokenFromCli = "new_token_from_cli";
+
+            TokenHandler.MaybeSaveToken(newTokenFromCli);
+
+            var lines = ReadTestConfigFile();
+            Assert.Contains(Constants.YnabSectionKey, lines);
+            Assert.Contains($"{Constants.TokenString}={newTokenFromCli}", lines);
+            Assert.DoesNotContain($"{Constants.TokenString}={existingUserToken}", lines);
+        }
+        
+        // Additional test cases for robustness
+        [Fact]
+        public void MaybeSaveToken_AddsToken_WhenConfigFileExistsWithoutTokenEntryInSectionAndTokenIsValid()
+        {
+            string initialContent = $"{Constants.YnabSectionKey}\nSomeOtherKey=SomeValue\n";
+            CreateTestConfigFile(initialContent);
+            string newToken = "newly_added_token";
+
+            TokenHandler.MaybeSaveToken(newToken);
+
+            var lines = ReadTestConfigFile();
+            Assert.Contains(Constants.YnabSectionKey, lines);
+            Assert.Contains("SomeOtherKey=SomeValue", lines);
+            Assert.Contains($"{Constants.TokenString}={newToken}", lines);
+        }
+        
+        [Fact]
+        public void MaybeSaveToken_AddsTokenAndSection_WhenConfigFileIsEmptyAndTokenIsValid()
+        {
+            CreateTestConfigFile(""); // Empty file
+            string newToken = "token_for_empty_file";
+
+            TokenHandler.MaybeSaveToken(newToken);
+
+            var lines = ReadTestConfigFile();
+            Assert.Contains(Constants.YnabSectionKey, lines);
+            Assert.Contains($"{Constants.TokenString}={newToken}", lines);
+        }
+        
+        [Fact]
+        public void MaybeSaveToken_AddsTokenAndSection_WhenConfigFileExistsWithOtherSectionsAndTokenIsValid()
+        {
+            string initialContent = "[OtherSection]\nKey=Value\n";
+            CreateTestConfigFile(initialContent);
+            string newToken = "token_with_other_sections";
+
+            TokenHandler.MaybeSaveToken(newToken);
+
+            var lines = ReadTestConfigFile();
+            Assert.Contains("[OtherSection]", lines);
+            Assert.Contains("Key=Value", lines);
+            Assert.Contains(Constants.YnabSectionKey, lines);
+            Assert.Contains($"{Constants.TokenString}={newToken}", lines);
+        }
+    }
 }


### PR DESCRIPTION
Adds functionality to automatically save the YNAB API token to `config.ini` when it is provided as a command-line argument (`--api-token` or `-t`).

Key changes:
- Added `--api-token` option to `BudgetCommandSettings`.
- Implemented `TokenHandler.MaybeSaveToken()` to handle the logic of validating and saving the token to `config.ini`. This method will overwrite an existing token in `config.ini` if a new one is provided via the CLI, including the default placeholder.
- Integrated this into the command execution flow in `BudgetCommand`.
- Added comprehensive tests for `TokenHandler.MaybeSaveToken()` to cover various scenarios, including:
    - Saving a new token when `config.ini` doesn't exist.
    - Overwriting a placeholder token.
    - Overwriting an existing user token.
    - Not saving invalid tokens (empty, whitespace, default placeholder).
    - Behavior with empty or malformed config files.

This feature streamlines the initial setup process for you by allowing you to set their API token directly from the command line on the first run (or any subsequent run where you wish to update the stored token), eliminating the need for manual editing of `config.ini`.