### PR TITLE
add integration test for embedded resource file

### DIFF
--- a/ynac.cli/_res/_DO_NOT_EDIT_THESE_FILES.md
+++ b/ynac.cli/_res/_DO_NOT_EDIT_THESE_FILES.md
@@ -5,4 +5,5 @@ They are used as a template to create other files.
 They should not be edited here unless the structure of the file has 
 changed and the template needs editing. 
 
-If the location of these files change, edit the embedded resource constants in Program.cs
+If the location of these files changes, edit the embedded resource constants in Constants.cs and the 
+corresponding Unit Tests in ynac.tests/ResourceTests.cs

--- a/ynac.tests/ResourceTests.cs
+++ b/ynac.tests/ResourceTests.cs
@@ -1,0 +1,22 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ynac.Tests;
+
+[TestClass]
+public class ResourceTests
+{
+   [TestMethod]
+    public void EmbeddedResource_Config_template_ini_ExistsWithContent()
+    { 
+        var cliAssembly = typeof(Program).Assembly; 
+
+        using var stream = cliAssembly.GetManifestResourceStream(Constants.ConfigFileTemplate);
+        
+        Assert.IsNotNull(stream, $"Embedded resource '{Constants.ConfigFileTemplate}' not found.");
+
+        using var reader = new StreamReader(stream);
+        var content = reader.ReadToEnd();
+
+        Assert.IsFalse(string.IsNullOrEmpty(content));
+    } 
+}


### PR DESCRIPTION
There will eventually need to be tests around ensuring that upgrading versions adds additional content to the config.ini but for now this test is all that is needed for resource files. This test is simply a safeguard to prevent against developer error (renames/deletes/etc). It serves no other practical purpose.