### PR TITLE
Hide age of money when hiding currency

### DIFF
--- a/ynac.cli/BudgetActions/ExitBudgetAction.cs
+++ b/ynac.cli/BudgetActions/ExitBudgetAction.cs
@@ -3,7 +3,7 @@ namespace ynac.BudgetActions;
 public class ExitBudgetAction : IBudgetAction
 {
     public string DisplayName  => "Exit"; 
-    public int Order  => 1; 
+    public int Order  => int.MaxValue; 
 
     public void Execute()
     {

--- a/ynac.cli/BudgetActions/MaskValuesAction.cs
+++ b/ynac.cli/BudgetActions/MaskValuesAction.cs
@@ -1,0 +1,17 @@
+namespace ynac.BudgetActions;
+
+internal class MaskValuesAction //: IBudgetAction
+{
+    IValueFormatter _formatter;
+    
+    public MaskValuesAction(IValueFormatter formatter)
+    {
+        _formatter = formatter;
+    }
+    public string DisplayName => _formatter.GetMasked() ? "Show Values" : "Mask Values";
+    public int Order => 1;
+    public void Execute()
+    {
+        _formatter.SetMasked(!_formatter.GetMasked()); 
+    }
+}

--- a/ynac.cli/CurrencyFormatting/CurrencyFormatterResolver.cs
+++ b/ynac.cli/CurrencyFormatting/CurrencyFormatterResolver.cs
@@ -1,0 +1,17 @@
+namespace ynac.CurrencyFormatting;
+
+internal class CurrencyFormatterResolver : ICurrencyFormatterResolver
+{
+    private readonly DefaultCurrencyFormatter _defaultFormatter;
+    private readonly MaskedCurrencyFormatter _maskedFormatter;
+
+    public CurrencyFormatterResolver(
+        DefaultCurrencyFormatter defaultFormatter, 
+        MaskedCurrencyFormatter maskedFormatter)
+    {
+        _defaultFormatter = defaultFormatter;
+        _maskedFormatter = maskedFormatter;
+    }
+    
+    public ICurrencyFormatter Resolve(bool isMasked) => isMasked ? _maskedFormatter : _defaultFormatter;
+}

--- a/ynac.cli/CurrencyFormatting/ICurrencyFormatter.cs
+++ b/ynac.cli/CurrencyFormatting/ICurrencyFormatter.cs
@@ -2,5 +2,9 @@ namespace ynac.CurrencyFormatting;
 
 public interface ICurrencyFormatter
 {
+    /// <summary>
+    /// Formats a given currency value based on the concrete implementation rules
+    /// </summary>
+    /// <param name="amount">a decimal representing the value to be formatted</param>
     string Format(decimal amount);
 }

--- a/ynac.cli/CurrencyFormatting/ICurrencyFormatterResolver.cs
+++ b/ynac.cli/CurrencyFormatting/ICurrencyFormatterResolver.cs
@@ -1,0 +1,6 @@
+namespace ynac.CurrencyFormatting;
+
+internal interface ICurrencyFormatterResolver
+{
+    ICurrencyFormatter Resolve(bool isMasked);
+}

--- a/ynac.cli/CurrencyFormatting/INSTRUCTIONS.md
+++ b/ynac.cli/CurrencyFormatting/INSTRUCTIONS.md
@@ -10,13 +10,13 @@ This folder defines how monetary amounts are formatted for display in the consol
 ## Components
 - ICurrencyFormatter: single method `string Format(decimal amount)`.
 - DefaultCurrencyFormatter: uses `amount.ToString("C")` (current culture) to format currency.
-- HiddenCurrencyFormatter: masks amounts and returns a placeholder string (currently `***.**`).
+- MaskedCurrencyFormatter: masks amounts and returns a placeholder string (`***.**`).
+- CurrencyFormatterResolver: resolves the active formatter at runtime based on the HideAmounts setting.
 
 ## Selection (DI)
-- YnacConsoleProvider registers the implementation based on settings:
-  - When HideAmounts is true: `ICurrencyFormatter = HiddenCurrencyFormatter`.
-  - Otherwise: `ICurrencyFormatter = DefaultCurrencyFormatter`.
-- HideAmounts can be set via:
+- YnacConsoleProvider registers DefaultCurrencyFormatter, MaskedCurrencyFormatter, and CurrencyFormatterResolver.
+- Code that needs a formatter obtains one via `ICurrencyFormatterResolver.Resolve(isMasked)`
+- Masking can be set via:
   - CLI flag: `-h|--hide-amounts`.
   - Config file: `[Ynac] HideAmounts = True|False`.
 
@@ -41,8 +41,8 @@ This folder defines how monetary amounts are formatted for display in the consol
 ## Testing
 - MSTest tests verify:
   - Default formatting matches en-US examples and is culture-sensitive.
-  - Hidden formatting returns the placeholder string for any input.
+  - Masked formatting returns the placeholder string for any input.
 
 ## Notes
 - Keep the formatter selection isolated to DI so UI code stays simple.
-- If you change the HiddenCurrencyFormatter placeholder string, update tests accordingly.
+- If you change the MaskedCurrencyFormatter placeholder string, update tests accordingly.

--- a/ynac.cli/CurrencyFormatting/MaskedCurrencyFormatter.cs
+++ b/ynac.cli/CurrencyFormatting/MaskedCurrencyFormatter.cs
@@ -1,6 +1,6 @@
 namespace ynac.CurrencyFormatting;
 
-public class HiddenCurrencyFormatter : ICurrencyFormatter
+public class MaskedCurrencyFormatter : ICurrencyFormatter
 {
     public string Format(decimal amount)
     {

--- a/ynac.cli/IValueFormatter.cs
+++ b/ynac.cli/IValueFormatter.cs
@@ -3,6 +3,7 @@ namespace ynac;
 internal interface IValueFormatter
 {
     public void SetMasked(bool masked);	
+    public bool GetMasked();	
     public string Format(decimal amount);
     public string Format(int value);
 }

--- a/ynac.cli/IValueFormatter.cs
+++ b/ynac.cli/IValueFormatter.cs
@@ -1,0 +1,8 @@
+namespace ynac;
+
+internal interface IValueFormatter
+{
+    public void SetMasked(bool masked);	
+    public string Format(decimal amount);
+    public string Format(int value);
+}

--- a/ynac.cli/ValueFormatter.cs
+++ b/ynac.cli/ValueFormatter.cs
@@ -1,0 +1,46 @@
+using System.Globalization;
+using ynac.CurrencyFormatting;
+
+namespace ynac;
+
+internal class ValueFormatter : IValueFormatter
+{
+    private readonly ICurrencyFormatter _defaultCurrencyFormatter;
+    private readonly ICurrencyFormatter _hiddenCurrencyFormatter;
+    private bool _masked;
+
+    public ValueFormatter(
+        ICurrencyFormatter defaultCurrencyFormatter, 
+        ICurrencyFormatter hiddenCurrencyFormatter,
+        bool initiallyMasked = false)
+    {
+        _defaultCurrencyFormatter = defaultCurrencyFormatter;
+        _hiddenCurrencyFormatter = hiddenCurrencyFormatter;
+        _masked = initiallyMasked;
+    }
+
+    public void SetMasked(bool masked)
+    {
+        _masked = masked;
+    }
+
+    public string Format(decimal amount)
+    {
+        if (_masked)
+        {
+            return _hiddenCurrencyFormatter.Format(amount);
+        }
+		
+        return _defaultCurrencyFormatter.Format(amount);
+    }
+
+    public string Format(int value)
+    {
+        if (_masked)
+        {
+            return "***";
+        }
+
+        return value.ToString("N0", CultureInfo.CurrentCulture);
+    }
+}

--- a/ynac.cli/ValueFormatter.cs
+++ b/ynac.cli/ValueFormatter.cs
@@ -5,17 +5,14 @@ namespace ynac;
 
 internal class ValueFormatter : IValueFormatter
 {
-    private readonly ICurrencyFormatter _defaultCurrencyFormatter;
-    private readonly ICurrencyFormatter _hiddenCurrencyFormatter;
+    private readonly ICurrencyFormatterResolver _resolver;
     private bool _masked;
 
     public ValueFormatter(
-        ICurrencyFormatter defaultCurrencyFormatter, 
-        ICurrencyFormatter hiddenCurrencyFormatter,
+        ICurrencyFormatterResolver currencyFormatterResolver,
         bool initiallyMasked = false)
     {
-        _defaultCurrencyFormatter = defaultCurrencyFormatter;
-        _hiddenCurrencyFormatter = hiddenCurrencyFormatter;
+        _resolver = currencyFormatterResolver;
         _masked = initiallyMasked;
     }
 
@@ -26,12 +23,7 @@ internal class ValueFormatter : IValueFormatter
 
     public string Format(decimal amount)
     {
-        if (_masked)
-        {
-            return _hiddenCurrencyFormatter.Format(amount);
-        }
-		
-        return _defaultCurrencyFormatter.Format(amount);
+        return _resolver.Resolve(_masked).Format(amount);
     }
 
     public string Format(int value)

--- a/ynac.cli/ValueFormatter.cs
+++ b/ynac.cli/ValueFormatter.cs
@@ -21,6 +21,11 @@ internal class ValueFormatter : IValueFormatter
         _masked = masked;
     }
 
+    public bool GetMasked()
+    {
+        return _masked;
+    }
+
     public string Format(decimal amount)
     {
         return _resolver.Resolve(_masked).Format(amount);

--- a/ynac.cli/YnacConsole.cs
+++ b/ynac.cli/YnacConsole.cs
@@ -6,7 +6,6 @@ using ynac.BudgetActions;
 using ynac.BudgetSelection;
 using ynac.Commands;
 using ynac.OSFeatures;
-using ynac.CurrencyFormatting;
 
 namespace ynac;
 
@@ -15,7 +14,7 @@ internal class YnacConsole(
     IBudgetBrowserOpener budgetBrowserOpener,
     IBudgetSelector budgetSelector,
     IEnumerable<IBudgetAction> budgetActions,
-    ICurrencyFormatter currencyFormatter,
+    IValueFormatter valueFormatter,
 	IAnsiConsoleService ansiConsoleService
 ) : IYnacConsole
 {
@@ -120,16 +119,16 @@ internal class YnacConsole(
 			
 				subTable.AddRow(
 					categoryCell,
-					new Markup($"[green]{currencyFormatter.Format(budgetedDollars)}[/]"),
-					new Markup($"[red]{currencyFormatter.Format(activityDollars)}[/]"),
-					new Markup($"[green]{currencyFormatter.Format(availableDollars)}[/]")
+					new Markup($"[green]{valueFormatter.Format(budgetedDollars)}[/]"),
+					new Markup($"[red]{valueFormatter.Format(activityDollars)}[/]"),
+					new Markup($"[green]{valueFormatter.Format(availableDollars)}[/]")
 				);
 			}
 			subTable.ShowFooters().AddRow(
 				"", 
-				$"[green]{currencyFormatter.Format(totalBudgeted)}[/]",
-				$"[red]{currencyFormatter.Format(totalActivity)}[/]",
-				$"[green]{currencyFormatter.Format(totalAvailable)}[/]"
+				$"[green]{valueFormatter.Format(totalBudgeted)}[/]",
+				$"[red]{valueFormatter.Format(totalActivity)}[/]",
+				$"[green]{valueFormatter.Format(totalAvailable)}[/]"
 			).ShowRowSeparators().MinimalBorder();
 
 			table.AddRow(subTable);
@@ -146,9 +145,9 @@ internal class YnacConsole(
 		
 		var columnText = $"[bold white][[[/] [yellow]{budgetName}[/] [bold white]]][/]" +
 		                 $"                 " +
-		                 $"[white]Age of money:[/] [aqua]{selectedBudget.AgeOfMoney ?? 0}[/]\n" +
+		                 $"[white]Age of money:[/] [aqua]{valueFormatter.Format(selectedBudget.AgeOfMoney ?? 0)}[/]\n" +
 		                 $"                            " +
-		                 $"To Be Budgeted: [green]{currencyFormatter.Format(selectedBudget.ToBeBudgeted/1000)}[/]";
+		                 $"To Be Budgeted: [green]{valueFormatter.Format(selectedBudget.ToBeBudgeted/1000)}[/]";
 		
 		table.AddColumn(columnText);
 

--- a/ynac.cli/YnacConsoleProvider.cs
+++ b/ynac.cli/YnacConsoleProvider.cs
@@ -20,7 +20,8 @@ public static class YnacConsoleProvider
         services.AddSingleton<ICurrencyFormatterResolver, CurrencyFormatterResolver>();
         services.AddSingleton<MaskedCurrencyFormatter>();
         services.AddSingleton<DefaultCurrencyFormatter>();
-        services.AddSingleton<IValueFormatter, ValueFormatter>();
+        services.AddSingleton<IValueFormatter>(sp => 
+            new ValueFormatter(sp.GetRequiredService<ICurrencyFormatterResolver>(), settings.HideAmounts));
 
         // other required dependencies
         services.AddSingleton<IYnacConsole, YnacConsole>();
@@ -49,6 +50,7 @@ public static class YnacConsoleProvider
         services.AddSingleton<IBudgetSelector, BudgetSelector>();
         
         services.AddSingleton<IBudgetAction, ExitBudgetAction>();
+        //services.AddSingleton<IBudgetAction, MaskValuesAction>();
         // add back when implemented
         //services.AddSingleton<IBudgetAction, ListTransactionsBudgetAction>(); 
         

--- a/ynac.cli/YnacConsoleProvider.cs
+++ b/ynac.cli/YnacConsoleProvider.cs
@@ -17,14 +17,10 @@ public static class YnacConsoleProvider
         
         services.AddYnabApi(settings.Token);
 
-        if (settings.HideAmounts)
-        {
-            services.AddSingleton<ICurrencyFormatter>(new HiddenCurrencyFormatter());
-        }
-        else
-        {
-            services.AddSingleton<ICurrencyFormatter>(new DefaultCurrencyFormatter());
-        }
+        services.AddSingleton<ICurrencyFormatterResolver, CurrencyFormatterResolver>();
+        services.AddSingleton<MaskedCurrencyFormatter>();
+        services.AddSingleton<DefaultCurrencyFormatter>();
+        services.AddSingleton<IValueFormatter, ValueFormatter>();
 
         // other required dependencies
         services.AddSingleton<IYnacConsole, YnacConsole>();

--- a/ynac.tests/CurrencyFormatting/CurrencyFormatterResolverTests.cs
+++ b/ynac.tests/CurrencyFormatting/CurrencyFormatterResolverTests.cs
@@ -1,0 +1,43 @@
+using ynac.CurrencyFormatting;
+
+namespace ynac.Tests.CurrencyFormatting;
+
+[TestClass]
+public class CurrencyFormatterResolverTests
+{
+    private readonly DefaultCurrencyFormatter defaultCurrencyFormatter = new();
+    private readonly MaskedCurrencyFormatter maskedCurrencyFormatter = new();
+    
+    private readonly ICurrencyFormatterResolver _sut;
+
+    public CurrencyFormatterResolverTests()
+    {
+        _sut = new CurrencyFormatterResolver(defaultCurrencyFormatter, maskedCurrencyFormatter);
+    }
+
+    [TestMethod]
+    public void CurrencyFormatterResolver_Resolve_ReturnsMaskedCurrencyFormatter_WhenTrue()
+    {
+        // Arrange
+        var isMasked = true;
+        
+        // Act
+        var resolved = _sut.Resolve(isMasked);
+        
+        // Assert
+        Assert.IsNotNull(resolved);
+        Assert.IsTrue(resolved is MaskedCurrencyFormatter);
+    }
+    
+    [TestMethod]
+    public void CurrencyFormatterResolver_Resolve_ReturnsDefaultFormatter_WhenFalse()
+    {
+        // Arrange
+        var isMasked = false;
+        
+        var resolved = _sut.Resolve(isMasked);
+        
+        Assert.IsNotNull(resolved);
+        Assert.IsTrue(resolved is DefaultCurrencyFormatter);
+    }
+}

--- a/ynac.tests/CurrencyFormatting/CurrencyFormatterTests.cs
+++ b/ynac.tests/CurrencyFormatting/CurrencyFormatterTests.cs
@@ -58,7 +58,7 @@ public class CurrencyFormatterTests
     public void HiddenCurrencyFormatter_AlwaysReturnsHiddenString(double amountInput)
     {
         // Arrange
-        var formatter = new HiddenCurrencyFormatter();
+        var formatter = new MaskedCurrencyFormatter();
         var amount = (decimal)amountInput;
         var expectedOutput = "***.**"; // matches current HiddenCurrencyFormatter implementation
 

--- a/ynac.tests/ValueFormatterTests.cs
+++ b/ynac.tests/ValueFormatterTests.cs
@@ -1,0 +1,86 @@
+using ynac.CurrencyFormatting;
+
+namespace ynac.Tests;
+
+[TestClass]
+public class ValueFormatterTests
+{
+    private sealed class FakeCurrencyFormatter : ICurrencyFormatter
+    {
+        private readonly string _name;
+        public FakeCurrencyFormatter(string name) => _name = name;
+        public string Format(decimal amount) => $"{_name}:{amount}";
+    }
+    
+    private sealed class CapturingResolver : ICurrencyFormatterResolver
+    {
+        public bool? LastMaskFlag { get; private set; }
+        private readonly ICurrencyFormatter _unmasked;
+        private readonly ICurrencyFormatter _masked;
+
+        public CapturingResolver(ICurrencyFormatter unmasked, ICurrencyFormatter masked)
+        {
+            _unmasked = unmasked;
+            _masked = masked;
+        }
+
+        public ICurrencyFormatter Resolve(bool isMasked)
+        {
+            LastMaskFlag = isMasked;
+            return isMasked ? _masked : _unmasked;
+        }
+    }
+
+    [TestMethod]
+    public void Constructor_Defaults_To_Unmasked()
+    {
+        var resolver = new CapturingResolver(new FakeCurrencyFormatter("U"), new FakeCurrencyFormatter("M"));
+        var sut = new ValueFormatter(resolver); 
+
+        var result = sut.Format(10m);
+
+        Assert.AreEqual("U:10", result);
+        Assert.AreEqual(false, resolver.LastMaskFlag);
+        Assert.AreEqual(false, sut.GetMasked());
+    }
+
+    [TestMethod]
+    public void Constructor_Can_Start_Masked()
+    {
+        var resolver = new CapturingResolver(new FakeCurrencyFormatter("U"), new FakeCurrencyFormatter("M"));
+        var sut = new ValueFormatter(resolver, initiallyMasked: true);
+
+        var result = sut.Format(5m);
+
+        Assert.AreEqual("M:5", result);
+        Assert.AreEqual(true, resolver.LastMaskFlag);
+        Assert.AreEqual(true, sut.GetMasked());
+    }
+
+    [TestMethod]
+    public void SetMasked_Toggles_State_And_Affects_Decimal_Format()
+    {
+        var resolver = new CapturingResolver(new FakeCurrencyFormatter("U"), new FakeCurrencyFormatter("M"));
+        var sut = new ValueFormatter(resolver);
+
+        sut.SetMasked(true);
+        var maskedResult = sut.Format(3.5m);
+
+        sut.SetMasked(false);
+        var unmaskedResult = sut.Format(7.2m);
+
+        Assert.AreEqual("M:3.5", maskedResult);
+        Assert.AreEqual("U:7.2", unmaskedResult);
+    }
+
+    [TestMethod]
+    public void Format_Int_Masked_Returns_Asterisks()
+    {
+        var resolver = new CapturingResolver(new FakeCurrencyFormatter("U"), new FakeCurrencyFormatter("M"));
+        var sut = new ValueFormatter(resolver, initiallyMasked: true);
+
+        var result = sut.Format(999);
+
+        Assert.AreEqual("***", result);
+    }
+}


### PR DESCRIPTION
Fixes #84 

This pull request introduces a new abstraction for formatting currency and other values. It replaces the previous approach of selecting a currency formatter directly in DI, allowing for runtime manipulation of value masking.

Value formatting is now exposed through IValueFormatter.
Additionally, it renames the "HiddenCurrencyFormatter" to "MaskedCurrencyFormatter" and updates related documentation and tests.

Introduced `ICurrencyFormatterResolver` and its implementation `CurrencyFormatterResolver` to select the appropriate currency formatter (masked or default) at runtime based on masking state. (`ynac.cli/CurrencyFormatting/ICurrencyFormatterResolver.cs`, `ynac.cli/CurrencyFormatting/CurrencyFormatterResolver.cs`) [[1]](diffhunk://#diff-1473d24da95beb24b0fe23c1c0af53ea9da902fa46514082c522a3af00092ac1R1-R6) [[2]](diffhunk://#diff-29c68f77846c53ded26c6728dde8b42e4fd0bc1a03a753a49a76cf5a9c355480R1-R17)

Updated `YnacConsole` to use `IValueFormatter` for all value rendering, enabling runtime toggling of masked/unmasked display for both currency and integer values. (`ynac.cli/YnacConsole.cs`) [[1]](diffhunk://#diff-665f651898c9c564db9bbf5c7089f84fbc1694217f3ae7cf302803405d65bde6L18-R17) [[2]](diffhunk://#diff-665f651898c9c564db9bbf5c7089f84fbc1694217f3ae7cf302803405d65bde6L123-R131) [[3]](diffhunk://#diff-665f651898c9c564db9bbf5c7089f84fbc1694217f3ae7cf302803405d65bde6L149-R150)

Added a new `MaskValuesAction` class (not yet registered in DI) to allow users to toggle masking interactively in the future. (`ynac.cli/BudgetActions/MaskValuesAction.cs`)

Added unit tests for `CurrencyFormatterResolver` to verify correct resolution of masked and default formatters. (`ynac.tests/CurrencyFormatting/CurrencyFormatterResolverTests.cs`)